### PR TITLE
handle content from multiple attachments

### DIFF
--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -656,12 +656,12 @@ class MailIndex(object):
         _loader(part)
         if len(payload[0]) > 3:
           try:
-            textpart = lxml.html.fromstring(payload[0]).text_content()
+            textpart += lxml.html.fromstring(payload[0]).text_content()
           except:
             session.ui.warning('=%s/%s has bogus HTML.' % (msg_mid, msg_id))
-            textpart = payload[0]
+            textpart += payload[0]
         else:
-          textpart = payload[0]
+          textpart += payload[0]
       elif 'pgp' in part.get_content_type():
         keywords.append('pgp:has')
 


### PR DESCRIPTION
begin to cope with multiple attachments in an email - so an attached webpage will have body indexed.

Keywords getting deduplicated should evade issues from identical text/plain and text/html parts for html email.

If this is the right place to do this sort of thing, I'll add code for pdf attachment text extraction (where content will be certainly different to the email), and possibly xls/xlsx too depending on how many of these we have in practice.

Mailpile is really quite helpful. Happy to chat further -- @smithsam on twitter.
