### PR TITLE
Switch #! to env python2

### DIFF
--- a/mailpile/__init__.py
+++ b/mailpile/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import mailpile.app
 import mailpile.commands

--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 APPVER="0.0.0+github"
 ABOUT="""\
 Mailpile.py          a tool          Copyright 2011-2013, Bjarni R. Einarsson

--- a/mailpile/commands.py
+++ b/mailpile/commands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #
 # These are the Mailpile commands, the public "API" we expose for searching,
 # tagging and editing e-mail.

--- a/mailpile/httpd.py
+++ b/mailpile/httpd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #
 # Mailpile's built-in HTTPD
 #

--- a/mailpile/mailutils.py
+++ b/mailpile/mailutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #
 ## Dear hackers!
 ##

--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 import cgi
 import codecs
 import datetime

--- a/mailpile/ui.py
+++ b/mailpile/ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #
 # This file contains the UserInteraction and Session classes.
 #

--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #
 # Misc. utility functions for Mailpile.
 #

--- a/scripts/mailpile
+++ b/scripts/mailpile
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 import sys
 from mailpile.app import Main
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2.7
 from datetime import date
 from setuptools import setup
 from mailpile.app import APPVER

--- a/tests/perftest.out
+++ b/tests/perftest.out
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 results = {
  'postinglist_kb = 126': [
    (0.727, 63481),                                


### PR DESCRIPTION
The #! was inconsistent across the project, using /usr/bin/env python, /usr/bin/env python2 and /usr/bin/python.

I normalized it to /usr/bin/env python2 which should work on most systems.

It also makes mailpile that much closer to running out of the box on archlinux.
