### PR TITLE
http: check if index is present

### DIFF
--- a/mailpile/httpd.py
+++ b/mailpile/httpd.py
@@ -239,6 +239,9 @@ class HttpRequestHandler(SimpleXMLRPCRequestHandler):
     elif path.endswith('.txt'):   session.ui.render_mode = 'text'
     else:                         session.ui.render_mode = 'html'
 
+    if not session.config.index:
+      session.ui.error("Index not found or empty, please check")
+      return
     try:
       cmd, data = self.parse_pqp(path, query_data, post_data, config)
       session.ui.html_variables = {


### PR DESCRIPTION
I had an error, while running the server:

Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 593, in process_request_thread
    self.finish_request(request, client_address)
  File "/home/benoit/projs/Mailpile/venv/local/lib/python2.7/site-packages/mailpile/httpd.py", line 281, in finish_request
    SimpleXMLRPCServer.finish_request(self, request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 649, in **init**
    self.handle()
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 340, in handle
    self.handle_one_request()
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 328, in handle_one_request
    method()
  File "/home/benoit/projs/Mailpile/venv/local/lib/python2.7/site-packages/mailpile/httpd.py", line 249, in do_GET
    'mailpile_size': len(session.config.index.INDEX)
