### PR TITLE
Don't die if index hasn't been initialized

### DIFF
--- a/mailpile/httpd.py
+++ b/mailpile/httpd.py
@@ -246,7 +246,7 @@ class HttpRequestHandler(SimpleXMLRPCRequestHandler):
         'csrf': 'FIXMEFIXME',
         'name': session.config.get('my_from', {1: 'Bradley Manning'}
                                    ).values()[0],
-        'mailpile_size': len(session.config.index.INDEX)
+        'mailpile_size': len(session.config.index.INDEX) if session.config.index else 0
       }
       if cmd:
         for arg in cmd.split(' /'):


### PR DESCRIPTION
Just checked out Mailpile without setting up any kind of mbox format, and needed this small fix to get the web interface to load
