### PR TITLE
Patch to show To: and Cc: fields in web interface

### DIFF
--- a/mailpile/commands.py
+++ b/mailpile/commands.py
@@ -50,6 +50,20 @@ class Command:
     __unicode__ = lambda self: self.as_text()
 
     def as_dict(self):
+      if (type(self.result)==list):
+        # add To and Cc fields to summary
+        for i in range(len(self.result)):
+          if "messages" in self.result[i]:
+            for j in range(len(self.result[i]['messages'])):
+              if "message" in self.result[i]['messages'][j] and \
+                     "headers" in self.result[i]['messages'][j]['message'] and\
+                     "summary" in self.result[i]['messages'][j]['message']:
+                if "To" in self.result[i]['messages'][j]['message']['headers']:
+                  self.result[i]['messages'][j]['message']['summary']['to'] = \
+                     self.result[i]['messages'][j]['message']['headers']['To']
+                if "Cc" in self.result[i]['messages'][j]['message']['headers']:
+                  self.result[i]['messages'][j]['message']['summary']['cc'] = \
+                     self.result[i]['messages'][j]['message']['headers']['Cc']
       return {
         'command': self.command,
         'result': self.result,

--- a/static/default/html/search.html
+++ b/static/default/html/search.html
@@ -43,6 +43,8 @@
 		                {.section summary}<ul class="message-headers">
 	                                <li><b>Date:</b> {date}</li>
                                 	<li><b>From:</b> {from}</li>
+                                	<li><b>To:</b> {to}</li>
+                                	<li><b>Cc:</b> {cc}</li>
                                 	<li><b>Subject:</b> {subject}</li>
                                 </ul>{.end}
                                 <div class="message-body">


### PR DESCRIPTION
this is not an ideal fix -- checking for fields in as_dict
and copying as necessary into summary
