### PR TITLE
To cc html

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Hey, check out our fundraiser! <http://igg.me/at/mailpile>**
 
-Mailpile (<http:/www.mailpile.is/>) is a free-as-in-freedom personal
+Mailpile (<http://www.mailpile.is/>) is a free-as-in-freedom personal
 e-mail searching and indexing tool, largely inspired by Google's popular
 proprietary-but-gratis e-mail service.  It wants to eventually become a
 fast and flexible back-end for awesome personal mail clients, including

--- a/static/default/html/search.html
+++ b/static/default/html/search.html
@@ -67,23 +67,23 @@ text {
                                 <input type=submit value='Save'>
                             {.or}
 		                {.section summary}<ul class="message-headers">
-	                                <li><b>Date:</b> {date}</li>
-                                	<li><b>From:</b> {from}</li>
+	                                <li><b>Date:</b> {date|html}</li>
+                                	<li><b>From:</b> {from|html}</li>
                         {.end}
                         {.section headers}
                         	{.section To}
-	                                <li><b>To:</b> {To}</li>
+	                                <li><b>To:</b> {To|html}</li>
                         	{.end}
                         	{.section Cc}
-	                                <li><b>Cc:</b> {Cc}</li>
+	                                <li><b>Cc:</b> {Cc|html}</li>
                         	{.end}
                         {.end}
 		                {.section summary}
-                                	<li><b>Subject:</b> {subject}</li>
+                                	<li><b>Subject:</b> {subject|html}</li>
                                 </ul>{.end}
                                 <div class="message-body">
 		                {.repeated section text_parts}
-                                        <p class="text-part-{type}">{data}</p>
+                                        <p class="text-part-{type}">{data|html}</p>
                                 {.end}</div>
                                 <ul class="message-attachments">
 		                {.repeated section attachments}


### PR DESCRIPTION
This patch combines pull requests #135 and #146
fixes search.html to display To: and Cc: fields (if available); renders text properly as html
