### PR TITLE
HTTPd : Add docs to some funcs & minor bugfixes

### DIFF
--- a/mailpile/httpd.py
+++ b/mailpile/httpd.py
@@ -83,9 +83,10 @@ class HttpRequestHandler(SimpleXMLRPCRequestHandler):
       self.send_header('WWW-Authenticate',
                        'Basic realm=MP%d' % (time.time()/3600))
     #If suppress_body == True, we don't know the content length
+    contentLengthHeaders = []
     if not suppress_body:
-        header_list.append( ('Content-Length', len(message or '')))
-    self.send_standard_headers(header_list=header_list,
+        contentLengthHeaders = [ ('Content-Length', len(message or '')) ]
+    self.send_standard_headers(header_list=header_list + contentLengthHeaders,
                                mimetype=mimetype,
                                cachectrl="no-cache")
     #Response body


### PR DESCRIPTION
This adds docstrings to some httpd methods, and fixes some minor/rare bugs:
- Should not send zero 'Content-Length' header if suppress_body == True
- send_file: File descriptor not closed, relying on specific behaviour of python implementation to close it automatically. It's cleaner to close it after being finished

Please feel free to tell me if you don't like mixed doc/bugfix pull requests!
