### PR TITLE
MailIndex._extract_date in mailpile/search.py can now handle there being...

### DIFF
--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -455,7 +455,7 @@ class MailIndex(object):
 
   def _extract_date(self, session, msg_mid, msg_id, msg, last_date):
     """Extract a date, sanity checking against the Received: headers."""
-    hdrs = [self.hdr(msg, 'date')] + msg.get_all('received')
+    hdrs = [self.hdr(msg, 'date')] + (msg.get_all('received') or [])
     dates = [self._parse_date(date_hdr) for date_hdr in hdrs]
     msg_date = dates[0]
     nz_dates = sorted([d for d in dates if d])


### PR DESCRIPTION
I used gmvault to import my gmail inbox and then tried adding + scanning with mailpile, it threw an error on a message that didn't contain a Received header.
