### PR TITLE
Adding early windows compatibility

### DIFF
--- a/mp.cmd
+++ b/mp.cmd
@@ -1,2 +1,2 @@
 @set PYTHONPATH=%~dp0
-@start c:\python27\python.exe scripts\mailpile %*
+@c:\python27\python.exe scripts\mailpile %*


### PR DESCRIPTION
I have made a first attempt to get mailpile working on my windows machine. I have tested it up to the "mailpile>" prompt and initial webpage launch. I have not (yet) imported my mail (from gmvault).

Download links I used to resolve dependencies I have found (so far):
- python 2.7: http://www.python.org/download/
- lxml (match the bitness of your python install): http://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml
- pyreadline: https://pypi.python.org/pypi/pyreadline/2.0

Attached is a windows-equivalent to "mp" in the root directory. This should match the behavior of the existing "mp" assuming the user installed python 2.7 in the default installation location.

GnuPGInterface does NOT appear to be installable for windows architectures. Despite an apparent ChangeLog stating otherwise ( http://freecode.com/projects/pygnupg ), unit tests are failing and I'm seeing an "import fcntl", which is very unix-specific and cannot be ported to windows. There is an open ticket ( http://sourceforge.net/p/py-gnupg/feature-requests/4/ ) to transition to a platform-independent alternative, but it feels a bit... old.
