### PR TITLE
ANSI-colored logging and prompt

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -643,7 +643,9 @@ def Interact(session):
   try:
     while True:
       session.ui.block()
-      opt = raw_input('mailpile> ').decode('utf-8').strip()
+      #Bold gray prompt, if output is a TTY
+      prompt = '\x1B[30;1mmailpile> \x1B[0m' if sys.stdout.isatty() else 'mailpile> '
+      opt = raw_input(prompt).decode('utf-8').strip()
       session.ui.unblock()
       if opt:
         if ' ' in opt:

--- a/mailpile/ui.py
+++ b/mailpile/ui.py
@@ -77,7 +77,23 @@ class UserInteraction:
       sys.stderr.write('\r')
     elif self.last_display[0] not in (self.LOG_RESULT, ):
       sys.stderr.write('\n')
-    sys.stderr.write('%s%s' % (text.encode('utf-8'), pad))
+        #On TTYs, print color-coded message
+    ansiPrefix = ''
+    ansiPostfix = ''
+    if sys.stderr.isatty():
+        #Generate an ANSI color from the loglevel
+        colorCode = "30" #Black, nothing special
+        if level is self.LOG_URGENT: colorCode = "31;1" #Bold red
+        elif level is self.LOG_ERROR: colorCode = "31" #Red
+        elif level is self.LOG_WARNING: colorCode = "33" #Yellow
+        elif level is self.LOG_PROGRESS: colorCode = "34" #Blue
+        #Generate a print prefix and postfix
+        ansiPrefix = "\x1B[%sm" % colorCode
+        ansiPostfix = "\x1B[0m"
+    sys.stderr.write('%s%s%s%s' % (ansiPrefix,
+                                   text.encode('utf-8'),
+                                   pad,
+                                   ansiPostfix))
     self.last_display = [level, len(text)]
   def clear_log(self):
     self.log_buffer = []


### PR DESCRIPTION
This pull request adds ANSI colors, if the output terminal is a TTY. The _mailpile>_ prompt is logged in bold-gray, and the log message color depends on the log level.
