### PR TITLE
Add python-imaging to debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,11 @@ Maintainer: Mailpile <team@mailpile.is>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 8), python (>= 2.7), python-gnupginterface (>= 0.3.2), python-lxml (>= 2.3.2)
+Build-Depends: debhelper (>= 8), python (>= 2.7), python-gnupginterface (>= 0.3.2), python-lxml (>= 2.3.2), python-imaging (>= 1.1.7)
 X-Python-Version: >= 2.6
 
 Package: mailpile
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, python-gnupginterface (>= 0.3.2), python-lxml (>= 2.3.2)
+Depends: ${python:Depends}, ${misc:Depends}, python-gnupginterface (>= 0.3.2), python-lxml (>= 2.3.2), python-imaging (>= 1.1.7)
 Homepage: https://mailpile.is
 Description: Mailpile


### PR DESCRIPTION
This adds _python-imaging (>= 1.1.7)" to the debian dependencies, to keep up to date with the *README_ deps.
