### PR TITLE
Improve util.py

### DIFF
--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -72,7 +72,7 @@ def sha1b64(s):
   '9/+ei3uy4Jtwk1pdeF4MxdnQq/A=\\n'
   
   Keyword arguments:
-  s -- The strign to hash
+  s -- The string to hash
   """
   h = hashlib.sha1()
   if type(s) == type(unicode()):


### PR DESCRIPTION
This adds some more docs to util.py and enable the doctests when calling _python util.py_.

Some bugs that were fixed:
- _escape_html_ had limited functionality. Now using _cgi_ module from python core to get better results
- The _obfuscate_ parameter was used inconsistently, the doctest had a function, but in fact it's rather a salt. Maybe it should be renamed.
- The doctests were never called, plus they had invalid indentation after _>>>_, the _from mailpile import util_ caused errors and the _\n_ wasn't escaped.
- The size parameter in _thumbnail()_ was never used after being converted to _<width>x<height>_ string
