### PR TITLE
Mailpile should read HTML templates not from the current working directo...

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -656,7 +656,7 @@ class ConfigManager(dict):
         if mkdir and not os.path.exists(cpath):
           os.mkdir(cpath)
       else:
-        bpath = os.path.join('.', bpath)
+        bpath = os.path.join(os.path.dirname(__file__), '..', bpath)
     return bpath
 
   def open_file(self, ftype, fpath, mode='rb', mkdir=False):


### PR DESCRIPTION
...ry but rather from the directory within the source-tree if possible.

This fixes out-of-the-box running of Mailpile on Windows for me. I started it from the scripts\ directory accidentally and it was unable to find its HTML templates because of this (the WWW frontend simply printed JSON, and no error message, making it very hard to figure out there even was a working UI!).

This patch will try as a last fallback to read the templates relative to the directory where the mailpile python files are.
If MAILPILE_HOME is set, that setting still takes precedence.
