### PR TITLE
Use Jinja2 == 2.7.1 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml==2.3.2
 http://sourceforge.net/projects/py-gnupg/files/GnuPGInterface/0.3.2/GnuPGInterface-0.3.2.tar.gz
-Jinja2==dev
+Jinja2==2.7.1


### PR DESCRIPTION
Currently  'pip install -r requirements.txt' shows:

```
Downloading/unpacking Jinja2==dev (from -r requirements.txt (line 3))

Could not find a version that satisfies the requirement Jinja2==dev (from -r requirements.txt (line 3)) (from versions: 2.0, 2.0rc1, 2.1.1, 2.1, 2.2.1, 2.2, 2.3.1, 2.3, 2.4.1, 2.4, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5, 2.5, 2.6, 2.7.1, 2.7, 2.0, 2.0rc1, 2.1.1, 2.1, 2.2.1, 2.2, 2.3.1, 2.3, 2.4.1, 2.4, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5, 2.5, 2.6, 2.7.1, 2.7, 2.0, 2.0rc1, 2.1.1, 2.1, 2.2.1, 2.2, 2.3.1, 2.3, 2.4.1, 2.4, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5, 2.5, 2.6, 2.7.1, 2.7, 2.0, 2.0rc1, 2.1.1, 2.1, 2.2.1, 2.2, 2.3.1, 2.3, 2.4.1, 2.4, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5, 2.5, 2.6, 2.7.1, 2.7, 2.0, 2.0rc1, 2.1.1, 2.1, 2.2.1, 2.2, 2.3.1, 2.3, 2.4.1, 2.4, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5, 2.5, 2.6, 2.7.1, 2.7, 2.5.4, 2.3.1, 2.2.1, 2.1, 2.4, 2.2, 2.1.1, 2.5.3, 2.4.1, 2.0rc1, 2.0, 2.3, 2.5.5, 2.5, 2.5.1, 2.5.2, 2.6, 2.7, 2.7.1, 2.5.4, 2.3.1, 2.2.1, 2.1, 2.4, 2.2, 2.1.1, 2.5.3, 2.4.1, 2.0rc1, 2.0, 2.3, 2.5.5, 2.5, 2.5.1, 2.5.2, 2.6, 2.7, 2.7.1)

No distributions matching the version for Jinja2==dev (from -r requirements.txt (line 3))
```

This PR sets Jinja2 version to latest stable (2.7.1)
