### PR TITLE
Use setuptools.find_packages() instead of hardcoding python packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 from datetime import date
-from setuptools import setup
+from setuptools import setup, find_packages
 from mailpile.app import APPVER
 import os
 
@@ -24,7 +24,7 @@ Mailpile is a tool for building and maintaining a tagging search
 engine for a personal collection of e-mail.  It can be used as a
 simple web-mail client.
 """,
-   packages=['mailpile','mailpile.plugins','mailpile.mailboxes'],
+   packages=find_packages(),
    entry_points = {
      'console_scripts': [
        'mailpile = mailpile.__main__:main'


### PR DESCRIPTION
_make virtualenv_ is currently missing the _mailboxes_ package. It installs using _setup.py_, so this pull request adds the mailboxes package to setup.py.

*_EDIT: *_ Now uses setuptools.find_packages() , thanks to @iElectric 
