### PR TITLE
Change requirements.txt to use pip's git format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml==2.3.2
 http://sourceforge.net/projects/py-gnupg/files/GnuPGInterface/0.3.2/GnuPGInterface-0.3.2.tar.gz
-Jinja2==dev
+git+https://github.com/mitsuhiko/jinja2.git#egg=Jinja2


### PR DESCRIPTION
Using this instead of 'dev' makes `make virtualenv` work
