### PR TITLE
Minor improvements in utils.py

### DIFF
--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -93,12 +93,15 @@ def sha1b64(s):
 
     >>> sha1b64("Hello")
     '9/+ei3uy4Jtwk1pdeF4MxdnQq/A=\\n'
+    
+    >>> sha1b64(u"Hello")
+    '9/+ei3uy4Jtwk1pdeF4MxdnQq/A=\\n'
 
     Keyword arguments:
     s -- The string to hash
     """
     h = hashlib.sha1()
-    if type(s) == type(unicode()):
+    if isinstance(s, unicode):
         h.update(s.encode('utf-8'))
     else:
         h.update(s)
@@ -120,7 +123,7 @@ def sha512b64(*data):
     """
     h = hashlib.sha512()
     for s in data:
-        if type(s) == type(unicode()):
+        if isinstance(s, unicode):
             h.update(s.encode('utf-8'))
         else:
             h.update(s)


### PR DESCRIPTION
In the hash functions in util.py, added a missing unit test and use _isinstance(s, unicode)_ instead of _type(s) == type(unicode)_. This makes it more flexible. See e.g. http://stereochro.me/ideas/type-vs-isinstance for arguments why you should use isinstance.
