### PR TITLE
Fixes for the PEP8 warning "E111 indentation is not a multiple of four".

### DIFF
--- a/mailpile/plugins/tags.py
+++ b/mailpile/plugins/tags.py
@@ -502,9 +502,9 @@ class ListFilters(Command):
             if self.result is False:
                 return unicode(self.result)
             return '\n'.join([' %3.3s %-20s %-25s %s' % (
-                                  r['fid'], r['terms'],
-                                  r['human_tags'], r['comment']
-                              ) for r in self.result])
+                                    r['fid'], r['terms'],
+                                    r['human_tags'], r['comment']
+                                ) for r in self.result])
 
     def command(self, want_fid=None):
         results = []


### PR DESCRIPTION
If it's ok with you guys, I'm going to work on this little by little. Each python file will be a commit in this pull request.

Fixing this warning everywhere will move towards consistent formatting for the code base.

I'll post another comment when this pull request is ready for review from a core developer.

Please see http://www.python.org/dev/peps/pep-0008/ for details on what I'm working towards with this.
