### PR TITLE
Make sys.path entry independent of location

### DIFF
--- a/scripts/mailpile
+++ b/scripts/mailpile
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 import sys, os
 
-# add root to sys.path so imports work without PYTHONPATH
-sys.path.append(os.path.dirname(__file__))
+# Make imports work without PYTHONPATH
+sys.path.append(
+  os.path.dirname(              # Mailpile root
+    os.path.dirname(              # scripts/
+      os.path.realpath(__file__)))) # this script
 
 from mailpile.app import Main
 


### PR DESCRIPTION
This makes it possible to invoke "mp" through a symbolic
link from anywhere.

We use as a reference the location of the actual scripts/mailpile
script, with all symlinks resolved, rather than the name the user
used to invoke the script, which may e.g. be a symbolic link in ~/bin/.

As a bonus (?), the script can now be invoked directly as
scripts/mailpile, rather than through the 'mp' symlink.
