### PR TITLE
Change size icons are now displayed in one line.

### DIFF
--- a/static/default/html/search/index.html
+++ b/static/default/html/search/index.html
@@ -19,11 +19,13 @@
     <div id="pile-bottom" class="clearfix">
       <a href="#" class="button-primary">Previous</a> <a href="/in/Inbox/@20/" class="button-primary">Next</a>
       <div>
-        <h5>{% if result.total > 1 %}{{result.start}} - {{result.end}} of {{result.total}} Messages {% elif result.total == 1 %} 1 Message {% else %} No results found {% endif %}</h5><br>
-        <a class="change-view-size" data-view_size="snug" href="#">Snug</a>
-        <a class="change-view-size" data-view_size="cozy" href="#">Cozy</a>
-        <a class="change-view-size" data-view_size="comfy" href="#">Comfy</a>
-        <a class="change-view-size" data-view_size="fluffy" href="#">Fluffy</a>
+        <h5>{% if result.total > 1 %}{{result.start}} - {{result.end}} of {{result.total}} Messages {% elif result.total == 1 %} 1 Message {% else %} No results found {% endif %}</h5>
+        <ul>
+          <li><a class="change-view-size" data-view_size="snug" href="#">Snug</a></li>
+          <li><a class="change-view-size" data-view_size="cozy" href="#">Cozy</a></li>
+          <li><a class="change-view-size" data-view_size="comfy" href="#">Comfy</a></li>
+          <li><a class="change-view-size" data-view_size="fluffy" href="#">Fluffy</a></li>
+        </ul>
       </div>
     </div>
   </form>

--- a/static/default/less/app-web/pile.less
+++ b/static/default/less/app-web/pile.less
@@ -136,6 +136,14 @@
     color: @black;
   }
 
+  #pile-bottom ul {
+    clear: both;
+  }
+
+  #pile-bottom ul > li {
+    display: inline;
+  }
+
 
 /* Pile	- Drag & Drop */
 	


### PR DESCRIPTION
Mailpile size icons are not aligned:

![mailpile_bug](https://f.cloud.github.com/assets/1262435/1505287/ea56327e-48d1-11e3-9c2e-69c6b9977adf.png)

This pull request fixes that.
