### PR TITLE
you can now "minify" javscript files with make js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docs:
 	python mailpile/urlmap.py >doc/URLS.md
 	python mailpile/defaults.py |grep -v ';timestamp' >doc/defaults.cfg
 
-web: less
+web: less js
 	@true
 
 alltests:
@@ -36,6 +36,10 @@ clean:
 virtualenv:
 	virtualenv mp-virtualenv
 	bash -c 'source mp-virtualenv/bin/activate && pip install -r requirements.txt && python setup.py install'
+
+js:
+	@cat static/default/js/mailpile.js > static/default/js/mailpile-min.js
+	@find static/default/js/app/ -name "*.js" -exec cat '{}' >> static/default/js/mailpile-min.js
 
 less: less-compiler
 	@make -s -f scripts/less-compiler.mk


### PR DESCRIPTION
Currently you have to copy/paste code to mailpile-min.js; this patch automates that.
It copies mailpile.js to mailpile-min.js and appends all javascript files located in static/default/js.

If you are interested in this patch I also offer moving comments from mailpile-min.js to respective non-minfied files and whitespace cleanup.
