### PR TITLE
Check tag object for being None and fallback else

### DIFF
--- a/mailpile/urlmap.py
+++ b/mailpile/urlmap.py
@@ -220,8 +220,8 @@ class UrlMap:
 
         tag_slug = '/'.join([p for p in path_parts[1:] if p])
         tag = self.session.config.get_tag(tag_slug)
-        tag_search = [tag.search_terms % tag]
-        if tag.search_order and 'order' not in query_data:
+        tag_search = [tag.search_terms % tag] if tag is not None else [""]
+        if tag is not None and tag.search_order and 'order' not in query_data:
             query_data['order'] = [tag.search_order]
 
         if pos:


### PR DESCRIPTION
I'm getting some weird issues when trying to access the MP web UI:

```
mailpile> Traceback (most recent call last):                                   
  File "/usr/local/lib/python2.7/dist-packages/mailpile-0.0.0_dev20131116-py2.7.egg/mailpile/httpd.py", line 213, in do_GET
    query_data, post_data)
  File "/usr/local/lib/python2.7/dist-packages/mailpile-0.0.0_dev20131116-py2.7.egg/mailpile/urlmap.py", line 353, in map
    return mapper(self, request, path_parts, query_data, post_data)
  File "/usr/local/lib/python2.7/dist-packages/mailpile-0.0.0_dev20131116-py2.7.egg/mailpile/urlmap.py", line 223, in _map_tag
    tag_search = [tag.search_terms % tag]
AttributeError: 'NoneType' object has no attribute 'search_terms'
```

I fixed that by checking _tag_ for None and falling back to an empty string instead. This leads to a new exception, which was fixed similarly:

```
AttributeError: 'NoneType' object has no attribute 'search_order'
```

By using these hacks, I can at least access the web interface when my CWD is the mailpile clone directory. I can reproduce this problem on Ubuntu 13.10 x64.
