### PR TITLE
Make mailpile auto-recognize the locale path

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -39,7 +39,7 @@ import gettext
 import mailpile.util
 import mailpile.defaults
 from mailpile.commands import COMMANDS, Action, Help, HelpSplash, Load, Rescan
-from mailpile.config import ConfigManager
+from mailpile.config import ConfigManager, getLocaleDirectory
 from mailpile.vcard import SimpleVCard
 from mailpile.mailutils import *
 from mailpile.httpd import *
@@ -102,7 +102,7 @@ def Main(args):
   re.LOCALE = 1
 
   # Bootstrap translations until we've loaded everything else
-  translation = gettext.translation("mailpile", "locale")
+  translation = gettext.translation("mailpile", getLocaleDirectory())
   translation.install(unicode=True)
 
   try:

--- a/mailpile/config.py
+++ b/mailpile/config.py
@@ -22,12 +22,15 @@ from mailpile.workers import Worker, DumbWorker, Cron
 
 # i18n helper
 if __name__ == "__main__":
-    translation = gettext.translation("mailpile", "locale")
+    translation = gettext.translation("mailpile", getLocaleDirectory())
     translation.install(unicode=True)
 else:
     _ = lambda x: x
 
-
+def getLocaleDirectory():
+    """Get the gettext translation object, no matter where our CWD is"""
+    # NOTE: MO files are loaded from the directory where the scripts reside in
+    return os.path.join(os.path.dirname(__file__), "..", "locale")
 
 class InvalidKeyError(ValueError):
     pass
@@ -1011,12 +1014,12 @@ class ConfigManager(ConfigDict):
         translation = None
         language = self.prefs.language
         if language != "":
-            translation = gettext.translation("mailpile", "locale", [language], codeset="utf-8")
+            translation = gettext.translation("mailpile", getLocaleDirectory(), [language], codeset="utf-8")
             if translation:
                 translation.set_output_charset("utf-8")
 
         if not translation:
-            translation = gettext.translation("mailpile", "locale")
+            translation = gettext.translation("mailpile", getLocaleDirectory())
 
         translation.install(unicode=True)
         return translation

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,11 @@ except:
   pass
 
 data_files = []
+#Copy static UI files
 for dir, dirs, files in os.walk('static'):
+    data_files.append((dir, [os.path.join(dir, file_) for file_ in files]))
+#Copy translation files
+for dir, dirs, files in os.walk('locale'):
     data_files.append((dir, [os.path.join(dir, file_) for file_ in files]))
 
 


### PR DESCRIPTION
Currently I can run MP only from the Mailpile clone directory, because it doesn't properly recognize the locale directory. _gettext_ searches in _[current CWD]/locale_ which obviously can't work.

This Pull Request:
- Installs the entire _locale_ directory in setup.py, just like the _static_ directory
- Uses the locale directory in _[path to config.py]/../locale_ in any case.

So, if you're running an installed version of Mailpile, it will work from everywhere (at least regarding that aspect).
If you're running mailpile from the clone directly, the behaviour will be the same as before.

Tested on Ubuntu 13.04 x64.
