### PR TITLE
Adding ignores for the coverage info and a test output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ static/default/plugins/
 doc/
 *.swp
 .vagrant
+.coverage
+testing/


### PR DESCRIPTION
I noticed that the .coverage file and a directory created by testing were not being ignored.
