### PR TITLE
Adding ignores for the coverage info and a test output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ doc/
 *.swp
 .vagrant
 .coverage
-testing/
+testing/tmp


### PR DESCRIPTION
I noticed that the .coverage file and a directory created by testing were not being ignored.
