### PR TITLE
Fix spelling of Received

### DIFF
--- a/locale/en_US/LC_MESSAGES/mailpile.po
+++ b/locale/en_US/LC_MESSAGES/mailpile.po
@@ -601,7 +601,7 @@ msgstr ""
 
 #: mailpile/search.py:304
 #, python-format
-msgid "=%s/%s using Recieved: instead of Date:"
+msgid "=%s/%s using Received: instead of Date:"
 msgstr ""
 
 #: mailpile/search.py:311


### PR DESCRIPTION
I just fixed the spelling of the word "Received" in mailpile.po.
