### PR TITLE
Allow shell quoting on CLI

### DIFF
--- a/mailpile/commands.py
+++ b/mailpile/commands.py
@@ -6,6 +6,7 @@ import json
 import os
 import os.path
 import re
+import shlex
 import traceback
 import time
 from gettext import gettext as _
@@ -110,7 +111,7 @@ class Command:
             self.args = list(arg)
         elif arg:
             if self.SPLIT_ARG:
-                self.args = arg.split(' ', self.SPLIT_ARG)
+                self.args = shlex.split(arg)[:self.SPLIT_ARG]
             else:
                 self.args = [arg]
         else:

--- a/mailpile/plugins/tags.py
+++ b/mailpile/plugins/tags.py
@@ -244,7 +244,7 @@ class AddTag(TagCommand):
     """Create a new tag"""
     SYNOPSIS = (None, 'tag/add', 'tag/add', '<tag>')
     ORDER = ('Tagging', 0)
-    SPLIT_ARG = False
+    SPLIT_ARG = 10000
     HTTP_CALLABLE = ('POST', )
     HTTP_POST_VARS = {
             'name': 'tag name',


### PR DESCRIPTION
Break up command-line args using shlex rather than string.split

This enables multiple-word tags using quotes:

mailpile> tag/add "three word tag"
mailpile> tag +"three word tag" 20
