### PR TITLE
Fix drafts' body formatting

### DIFF
--- a/static/default/html/message/draft.html
+++ b/static/default/html/message/draft.html
@@ -52,9 +52,7 @@
       </div>
     </div>
     <div class="compose-message">
-      <textarea id="compose-body" tabindex="4" name="body" placeholder="{{_("Your message...")}}">
-        {{message.editing_strings.body}}
-      </textarea>
+      <textarea id="compose-body" tabindex="4" name="body" placeholder="{{_("Your message...")}}">{{message.editing_strings.body}}</textarea>
     </div>
     <div class="compose-attachments">
       <span class="icon-attachment"></span> {{_("No Attachments")}}


### PR DESCRIPTION
Previously: 

```
foo
```

was displayed

```
        foo

```
