### PR TITLE
Fix vagrantfile

### DIFF
--- a/scripts/vagrant_bootstrap.sh
+++ b/scripts/vagrant_bootstrap.sh
@@ -6,7 +6,9 @@ AS_VAGRANT='sudo -u vagrant'
 
 echo 'Running bootstrap for Vagrant'
 echo '.. installing python libraries'
+apt-get update
 apt-get install -y python-imaging python-jinja2 python-lxml libxml2-dev libxslt1-dev
+ln -s /usr/bin/python2.7 /usr/bin/python2
 
 cd $MAILPILE_PATH
 


### PR DESCRIPTION
trivial fixes.

/usr/bin/python2 isn't linked in the box, and some packages are getting outdated so apt-get install doesn't work without apt-get update
