### PR TITLE
Fix 'Your profile' having not enough top margin

### DIFF
--- a/static/default/css/default.css
+++ b/static/default/css/default.css
@@ -6113,7 +6113,7 @@ text {
 /* Content */
 div.content-normal {
   position: relative;
-  margin: 30px 25px;
+  margin: 85px 25px;
 }
 /* Footer */
 #footer {


### PR DESCRIPTION
In Chrome on Linux (using the german translation), the _div#settings_ doesn't have enough top margin.

This pull request fixes that.

Before: http://i.imgur.com/YPgf3l4.jpg

After: http://i.imgur.com/1XP0LHI.png

Merging would be highly appreciated
