### PR TITLE
type="text/javascript" is redundant

### DIFF
--- a/static/default/html/layouts/base.html
+++ b/static/default/html/layouts/base.html
@@ -34,11 +34,11 @@
 
   <title>{% block title %}{{title}}{% endblock %} | {{name}}'s mailpile</title>
 
-<script type="text/javascript" src="/static/js/libraries/jquery.min.js"></script>
-<script type="text/javascript" src="/static/js/libraries-min.js"></script>
-<script type="text/javascript" src="/static/js/libraries/d3.v3.min.js"></script>
-<script type="text/javascript" src="/static/js/libraries/dropdown.js"></script>
-<script type="text/javascript" src="/static/js/libraries/modal.js"></script>
+<script src="/static/js/libraries/jquery.min.js"></script>
+<script src="/static/js/libraries-min.js"></script>
+<script src="/static/js/libraries/d3.v3.min.js"></script>
+<script src="/static/js/libraries/dropdown.js"></script>
+<script src="/static/js/libraries/modal.js"></script>
 </head>
 <body>
 
@@ -193,27 +193,27 @@
   </ul>
 </div>
 
-<script type="text/javascript" src="/static/js/mailpile.js"></script>
-<script type="text/javascript" src="/static/js/app/notifications.js"></script>
-<script type="text/javascript" src="/static/js/app/tooltips.js"></script>
-<script type="text/javascript" src="/static/js/app/gpg.js"></script>
-<script type="text/javascript" src="/static/js/app/compose.js"></script>
-<script type="text/javascript" src="/static/js/app/pile.js"></script>
-<script type="text/javascript" src="/static/js/app/search.js"></script>
-<script type="text/javascript" src="/static/js/app/thread.js"></script>
-<script type="text/javascript" src="/static/js/app/contacts.js"></script>
-<script type="text/javascript" src="/static/js/app/tags.js"></script>
-<script type="text/javascript" src="/static/js/app/settings.js"></script>
+<script src="/static/js/mailpile.js"></script>
+<script src="/static/js/app/notifications.js"></script>
+<script src="/static/js/app/tooltips.js"></script>
+<script src="/static/js/app/gpg.js"></script>
+<script src="/static/js/app/compose.js"></script>
+<script src="/static/js/app/pile.js"></script>
+<script src="/static/js/app/search.js"></script>
+<script src="/static/js/app/thread.js"></script>
+<script src="/static/js/app/contacts.js"></script>
+<script src="/static/js/app/tags.js"></script>
+<script src="/static/js/app/settings.js"></script>
 {% for asset in get_assets("javascript") %}<link rel="stylesheet" href="{{asset}}"/>
 {% endfor %}
-<script type="text/javascript">
+<script>
 mailpile.instance = {
  "command": "{{ command }}",
  "args": "{{ args }}",
  "search_terms": "{% for term in result.search_terms %}{{term}}{% if not loop.last %} {% endif %}{%endfor%}"
 }
 </script>
-<script type="text/javascript" src="/static/js/plugins-min.js"></script>
+<script src="/static/js/plugins-min.js"></script>
 
 </body>
 </html>{% endif %}{# html_in_json #}

--- a/static/default/index.html
+++ b/static/default/index.html
@@ -545,8 +545,8 @@
 
 	<!-- JS ================================================== -->
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-    <script type="text/javascript" src="http://jonrohan.github.io/ZeroClipboard/javascripts/ZeroClipboard.js" ></script>
-	<script type="text/javascript">
+    <script src="http://jonrohan.github.io/ZeroClipboard/javascripts/ZeroClipboard.js" ></script>
+	<script>
 
 
 		$('.gist').hide();


### PR DESCRIPTION
Just a small optimization/modernization to move the web forward.

`<script>` elements only need an explicit type when it is something other than JavaScript.

This is fully backwards compatible and compliant with HTML5.
