### PR TITLE
Simplified author list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Contributors:
 - Bjarni R. Einasson (<http://bre.klaki.net/>)
 - Smari McCarthy (<http://www.smarimccarthy.is/>)
 - Brennan Novak (<https://brennannovak.com/>)
-- Lots more, run `git log |grep Author |sort |uniq -c` for a list!
+- Lots more, run `git shortlog -s` for a list! (Or see the list [on Github](https://github.com/pagekite/Mailpile/graphs/contributors).)
 
 And of course, we couldn't do this without [our community of
 backers]().


### PR DESCRIPTION
Instead of filtering the complete git log, `git shortlog -s` (‘s’ for “summary”) can be used to view a list of authors with the number of their respective commits. `git shortlog` also has the benefit of respecting a .mailmap file if it exists, which allows to fix incorrect e-mails or names.
 In addition, Github also offers a list of contributors.

(I hope the Unicode characters in the message are okay?)
