### PR TITLE
Make setup.py work without lxml already installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python2
 from datetime import date
 from setuptools import setup, find_packages
-from mailpile.app import APPVER
 import os
 from glob import glob
+
+APPVER = iter(open('mailpile/app.py', 'r')).next().split('"')[1]
 
 try:
     # This borks sdist.


### PR DESCRIPTION
Importing mailpile.app fails in a new blank virtualenv because `lxml` is not installed. By just reading `APPVER` out of the source code instead of importing, `python setup.py install` works.
