### PR TITLE
[Issue #398] Fix help variables

### DIFF
--- a/mailpile/commands.py
+++ b/mailpile/commands.py
@@ -1002,7 +1002,7 @@ class Output(Command):
 
 class Help(Command):
     """Print help on Mailpile or individual commands."""
-    SYNOPSIS = ('h', 'help', 'help', '[<command-group>|variables]')
+    SYNOPSIS = ('h', 'help', 'help', '[<command-group>]')
     ABOUT = ('This is Mailpile!')
     ORDER = ('Config', 9)
 
@@ -1143,22 +1143,23 @@ class Help(Command):
 class HelpVars(Help):
     """Print help on Mailpile variables"""
     SYNOPSIS = (None, 'help/variables', 'help/variables', None)
+    ABOUT = ('The available mailpile variables')
     ORDER = ('Config', 9)
 
     def command(self):
         config = self.session.config.rules
         result = []
-        for cat in config.keys():
+        categories = ["sys", "prefs", "profiles"]
+        for cat in categories:
             variables = []
-            for what in config['sys'], config['profiles'], config['prefs']:
-                if what[2]:
-                    for ii, i in what[2].iteritems():
-                        variables.append({
-                            'var': ii,
-                            'type': str(i[1]),
-                            'desc': i[0]
-                        })
-
+            what = config[cat]
+            if isinstance(what[2], dict):
+                for ii, i in what[2].iteritems():
+                    variables.append({
+                        'var': ii,
+                        'type': str(i[1]),
+                        'desc': i[0]
+                    })
             variables.sort(key=lambda k: k['var'])
             result.append({
                 'category': cat,

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -49,6 +49,10 @@ class TestCommands(MailPileUnittest):
         res = self.mp.help()
         self.assertEqual(len(res.result), 3)
 
+    def test_help_variables(self):
+        res = self.mp.help_variables()
+        self.assertGreater(len(res.result['variables']), 1)
+
     def test_help_with_param_search(self):
         res = self.mp.help('search')
         self.assertEqual(res.result['pre'], 'Search your mail!')


### PR DESCRIPTION
See issue #398 basically this makes the command help/variables work, and shows the internal variables for mailpile from the cli.
