### PR TITLE
Ignore expired or revoked secret keys during setup

### DIFF
--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -1,5 +1,6 @@
 import os
 from gettext import gettext as _
+from datetime import date 
 
 import mailpile.plugins
 from mailpile.plugins import __all__ as PLUGINS
@@ -163,6 +164,10 @@ class Setup(Command):
                 pass
             else:
                 for key, details in keys.iteritems():
+                    # Ignore revoked/expired keys.
+                    if "revocation-date" in details and details["revocation-date"] <= date.today().strftime("%Y-%m-%d"):
+                        continue
+
                     for uid in details["uids"]:
                         if "email" not in uid or uid["email"] == "":
                             continue


### PR DESCRIPTION
./mp --setup would fail when the first available secret key was expired (or revoked).
