### PR TITLE
gmvault: Added missing mailbox import

### DIFF
--- a/mailpile/mailboxes/gmvault.py
+++ b/mailpile/mailboxes/gmvault.py
@@ -1,5 +1,6 @@
 import os
 import gzip
+import mailbox
 import rfc822
 
 import mailpile.mailboxes


### PR DESCRIPTION
It was impossible to add gmvault mailbox to Mailpile. It look like the bug was introduced when refactoring mailboxes into their own modules. Is there a need for more tests? This would be tested with something like
mailpile> add ~/gmvault-db
mailpile> rescan all
