### PR TITLE
Required dependencies missing from debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,6 @@ X-Python-Version: >= 2.6
 Package: mailpile
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, python-lxml (>= 2.3.2), python-imaging (>= 1.1.7), python-jinja2
+Suggests: spambayes
 Homepage: http://www.mailpile.is
 Description: Mailpile


### PR DESCRIPTION
Just watching your FOSDEM talk (which was excellent BTW), so took a look at the project.

After generating a debchange file I ran `dpkg-buildpackage -b` (very happy to see that /debian directory) and noticed that the `python2.7 setup.py build` command failed on a python-jinja2 error. Installing the package fixed it, so I figure this should be listed in control. It also seems required to run the mailpile command shell.

Further, the mailpile command shell `setup` command suggested to install spambayes, so we should probably add that suggestion to the control file also.

I don't know if there is a minimum required version of python-jinja2. If known, it can be added, but just mentioning it is an improvement. Tested on Debian GNU/Linux wheezy/stable.
