### PR TITLE
Fixed error with initial setup

### DIFF
--- a/mailpile/crypto/gpgi.py
+++ b/mailpile/crypto/gpgi.py
@@ -148,7 +148,7 @@ def parse_uid(uidstr):
         comment = matches.groups(0)[2] or ""
         name = matches.groups(0)[0] or ""
     else:
-        email = line[9]
+        email = ""
         name = ""
         comment = ""
 


### PR DESCRIPTION
On running `mp --setup` for the first time, it fails with:

```
Enabling gravatar image importer                                               
Importing contacts from GPG keyring                                            
Traceback (most recent call last):
  File "/usr/share/mailpile/mailpile/commands.py", line 271, in _run
    return self._finishing(command, command(self, *args, **kwargs))
  File "/usr/share/mailpile/mailpile/commands.py", line 268, in command
    return self.command(*args, **kwargs)
  File "/usr/share/mailpile/mailpile/plugins/setup_magic.py", line 160, in command
    keys = gnupg.list_secret_keys()
  File "/usr/share/mailpile/mailpile/crypto/gpgi.py", line 498, in list_secret_keys
    callbacks={"stdout": self.parse_keylist})
  File "/usr/share/mailpile/mailpile/crypto/gpgi.py", line 437, in run
    retvals[fd].append(callbacks[fd](buf))
  File "/usr/share/mailpile/mailpile/crypto/gpgi.py", line 343, in parse_keylist
    curkey, keys = r(parms, curkey, keys)
  File "/usr/share/mailpile/mailpile/crypto/gpgi.py", line 291, in parse_privkey
    curkey, keys = parse_pubkey(line, curkey, keys)
  File "/usr/share/mailpile/mailpile/crypto/gpgi.py", line 268, in parse_pubkey
    curkey, keys = parse_uidline(line, curkey, keys)
  File "/usr/share/mailpile/mailpile/crypto/gpgi.py", line 295, in parse_uidline
    email, name, comment = parse_uid(line[9])
  File "/usr/share/mailpile/mailpile/crypto/gpgi.py", line 151, in parse_uid
    email = line[9]
NameError: global name 'line' is not defined

Failed: setup                                                                  
```

This is fixed by changing `email = line[9]` to `email = ""`
