### PR TITLE
Fix charset handling

### DIFF
--- a/mailpile/mailutils.py
+++ b/mailpile/mailutils.py
@@ -825,7 +825,7 @@ class Email(object):
             return _('[Binary data suppressed]\n'), 'utf-8'
 
     def decode_payload(self, part):
-        charset = part.get_charset() or None
+        charset = part.get_content_charset() or None
         payload = part.get_payload(None, True) or ''
         return self.decode_text(payload, charset=charset)
 

--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -760,7 +760,7 @@ class MailIndex:
         for part in msg.walk():
             textpart = payload[0] = None
             ctype = part.get_content_type()
-            charset = part.get_charset() or 'iso-8859-1'
+            charset = part.get_content_charset() or 'iso-8859-1'
 
             def _loader(p):
                 if payload[0] is None:


### PR DESCRIPTION
get_charset() returns always None for parsed message ; use
get_content_charset() instead.

This bug can be demonstrated by sending an email containing Japanese
characters using a non-UTF8 charset (for example, EUC-JP)
