### PR TITLE
Fix debian/control problems

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,14 +1,14 @@
 Source: mailpile
 Maintainer: Mailpile <team@mailpile.is>
-Section: misc
+Section: mail
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 8), python (>= 2.7), python-lxml (>= 2.3.2), python-imaging (>= 1.1.7), python-jinja2
+Build-Depends: debhelper (>= 8), python (>= 2.7), python-lxml (>= 2.3.2), python-imaging (>= 1.1.7), python-jinja2, node-less, python-setuptools, python-nose
 X-Python-Version: >= 2.6
 
 Package: mailpile
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, python-lxml (>= 2.3.2), python-imaging (>= 1.1.7), python-jinja2
-Suggests: spambayes
+Depends: ${python:Depends}, ${misc:Depends}, python-lxml (>= 2.3.2), python-imaging (>= 1.1.7), python-jinja2, spambayes (= 1.1b)
+Recommends: gnupg
 Homepage: http://www.mailpile.is
-Description: Mailpile
+Description: Local mail container with a web-mail interface, and encryption.


### PR DESCRIPTION
Build-depend on node-less, python-setuptools, and python-nose.

A particular spambayes version is checked at run time, so Depend on that
or get error "pkg_resources.DistributionNotFound: spambayes==1.1b1" .  Note,
this version doesn't seem to be popular yet.

Recommend gnupg so it is usually installed along with mailpile, but not
strictly necessary.
