### PR TITLE
Use SVG for status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to Mailpile! #
 
-[![Build Status](https://secure.travis-ci.org/pagekite/Mailpile.png?branch=master)](http://travis-ci.org/pagekite/Mailpile)
+[![Build Status](https://img.shields.io/travis/pagekite/Mailpile/master.svg)](https://travis-ci.org/pagekite/Mailpile)
 
 #### Who's doing what? ####
 


### PR DESCRIPTION
http://shields.io/ provides many standardized badges for OSS. The PNG version provided by Shields is similar to the image currently used, but the SVG version added here is more legible on high pixel density displays.
