### PR TITLE
List timestamps with minutes and hours where appropriate.

### DIFF
--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -222,11 +222,22 @@ def elapsed_datetime(timestamp):
     """
     Return "X days ago" style relative dates for recent dates.
     """
-    ts = datetime.date.fromtimestamp(timestamp)
-    days_ago = (datetime.date.today() - ts).days
+    ts = datetime.datetime.fromtimestamp(timestamp)
+    elapsed = datetime.datetime.today() - ts
+    days_ago = elapsed.days
+    hours_ago, remainder = divmod(elapsed.seconds, 3600)
+    minutes_ago, seconds_ago = divmod(remainder, 60)
 
     if days_ago < 1:
-        return _('today')
+        if hours_ago < 1:
+            if minutes_ago < 5:
+                return _('just now')
+            elif minutes_ago >= 5:
+                return _('%d minutes') % minutes_ago
+        elif hours_ago < 2:
+            return _('%d hour') % hours_ago
+        else:
+            return _('%d hours') % hours_ago
     elif days_ago < 2:
         return _('%d day') % days_ago
     elif days_ago < 7:


### PR DESCRIPTION
This just changes the behavior of saying "today" in the inbox to being a bit more precise and listing minutes ago/hours ago when messages are less than one day old.
