### PR TITLE
Don't use server_url for 302 Found redirects

### DIFF
--- a/mailpile/httpd.py
+++ b/mailpile/httpd.py
@@ -72,7 +72,7 @@ class HttpRequestHandler(SimpleXMLRPCRequestHandler):
 
     def send_http_redirect(self, destination):
         if '//' not in destination:
-            destination = '%s%s' % (self.server_url(), destination)
+            pass#destination = '%s%s' % (self.server_url(), destination)
         self.send_http_response(302, 'Found')
         self.wfile.write(('Location: %s\r\n\r\n'
                           '<h1><a href="%s">Please look here!</a></h1>\n'


### PR DESCRIPTION
I'm using Mailpile remotely over an authenticated NGINX SSL tunnel. Mailpile is listening on localhost:33411 but I'm accessing it over https://something. If the redirect URL includes server_url, I will get redirected to localhost:33411, which I can't access remotely.

The Location header in a 302 response works just fine with relative URLs and is conform the latest HTTP 1.1 spec.
