### PR TITLE
layout fix in tag-settings homescreen.

### DIFF
--- a/static/default/html/tag/index.html
+++ b/static/default/html/tag/index.html
@@ -3,7 +3,7 @@
 {% set tag = result.tags.0 %}
 {% block title %}{{ tag.name }} | {{_("Tags")}} {% endblock %}
 {% block content %}
-<div id="tags-settings" class="content-normal clearfix">
+<div id="tags-settings" class="content-normal">
   <div class="clearfix">
     <h2 class="contact-name "><span class="icon-tag"></span> {{ tag.name }}</h2>
 	</div>


### PR DESCRIPTION
I have notice that under osx safary the tag-settings main content is missing the proper margins on the left and top. Suggested change seems to fix it under safari.
