### PR TITLE
Add python-pip dependency for debian-dev to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dev:
 debian-dev:
 	sudo apt-get install python-imaging python-lxml python-jinja2 pep8 \
 	                     ruby-dev yui-compressor python-nose spambayes \
-	                     phantomjs
+	                     phantomjs python-pip
 	if [ "$(shell cat /etc/debian_version)" = "jessie/sid"  ]; then\
 		 sudo apt-get install rubygems-integration;\
 	else \


### PR DESCRIPTION
It's currently missing. Should fix #607
