### PR TITLE
[#613] Add media print stylesheet

### DIFF
--- a/scripts/less-compiler.in
+++ b/scripts/less-compiler.in
@@ -8,4 +8,8 @@ static/default/css/default.css: .less-deps
 	    >../css/default.css)
 	@ls -l static/default/css/default.css
 
+static/default/css/print.css:
+	@(cd static/default/less && lessc print.less >../css/print.css)
+	@ls -l static/default/css/print.css
+
 .less-deps: scripts/less-compiler.in \

--- a/static/default/css/print.css
+++ b/static/default/css/print.css
@@ -1,0 +1,21 @@
+/**
+ * Use a readable font for print styles
+ */
+body {
+  font-family: Georgia, serif;
+  background: none;
+  color: black;
+}
+#sidebar,
+#header {
+  display: none;
+}
+#content {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  background: none;
+}
+.thread-item-text {
+  clear: both;
+}

--- a/static/default/html/partials/head.html
+++ b/static/default/html/partials/head.html
@@ -12,6 +12,7 @@
 ---------------------------------------------------------------------------- -->
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <link rel="stylesheet" href="/static/css/default.css" />
+  <link rel="stylesheet" href="/static/css/print.css" media="print" />
   <link rel="stylesheet" href="/jsapi/as.css" />
   
   <!--[if lt IE 9]>

--- a/static/default/less/print.less
+++ b/static/default/less/print.less
@@ -1,0 +1,19 @@
+/**
+ * Use a readable type for print styles
+ */
+body {
+  font-family: Georgia, serif;
+  background: none;
+  color: black;
+}
+
+#sidebar, #header {
+  display: none;
+}
+#content {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  bacckground: none;
+}
+.thread-item-text { clear: both }


### PR DESCRIPTION
Hey, I added a simple print.css stylesheet that makes things look reasonable. It should provide a good starting point that can be expanded upon when testing how print styles turn out cross-browser, etc.

Feel free to make any suggestions, I couldnt find how js/css is being minified, for instance I noticed default.css is minified, but couldnt find anything in the Makefiles  so I left that out for now...
