### PR TITLE
Fix Windows error when backup file doesn't fire and rename fails

### DIFF
--- a/mailpile/config.py
+++ b/mailpile/config.py
@@ -1087,8 +1087,8 @@ class ConfigManager(ConfigDict):
         fd.close()
 
         # Keep the last 5 config files around... just in case.
-        backup_file(self.conffile, backups=5, min_age_delta=10)
-        os.rename(newfile, self.conffile)
+        if backup_file(self.conffile, backups=5, min_age_delta=10):
+            os.rename(newfile, self.conffile)
 
         self.get_i18n_translation()
         self.prepare_workers()

--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -360,7 +360,7 @@ def decrypt_and_parse_lines(fd, parser, config,
 def backup_file(filename, backups=5, min_age_delta=0):
     if os.path.exists(filename):
         if os.stat(filename).st_mtime >= time.time() - min_age_delta:
-            return
+            return False
 
         for ver in reversed(range(1, backups)):
             bf = '%s.%d' % (filename, ver)
@@ -370,6 +370,8 @@ def backup_file(filename, backups=5, min_age_delta=0):
                     os.remove(nbf)
                 os.rename(bf, nbf)
         os.rename(filename, '%s.1' % filename)
+        return True
+    return False
 
 
 class GpgWriter(object):


### PR DESCRIPTION
Trying to run setup on Windows fails on the attempt to rename `mailpile.cfg.new` to `mailpile.cfg` because the file exists. This checks to make sure the file was actually renamed in `backup_file` before attempting to rename.
