### PR TITLE
Fix gpg key import

### DIFF
--- a/mailpile/crypto/gpgi.py
+++ b/mailpile/crypto/gpgi.py
@@ -323,7 +323,7 @@ class GnuPG:
         self.passphrase = None
         self.outputfds = ["stdout", "stderr", "status"]
         self.errors = []
-        self.homedir = None
+        self.homedir = GNUPG_HOMEDIR
 
     def set_home(self, path):
         self.homedir = path

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -74,6 +74,7 @@ def get_shared_mailpile():
     # force usage of test keyring whenever the test mailpile instance is used
     os.chmod(os.path.join(get_mailpile_root(), 'testing', 'gpg-keyring'),
              stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR)
+    global GNUPG_HOMEDIR
     GNUPG_HOMEDIR = os.path.join(get_mailpile_root(), 'testing', 'gpg-keyring')
 
     workdir = get_mailpile_root()


### PR DESCRIPTION
- Fixed broken code in GPG module (method parse_import had been accidentally deleted in )
- Reenforced gpg test keychain for tests
