### PR TITLE
Unemphasize close button in creation of new contact

### DIFF
--- a/static/default/html/partials/modals.html
+++ b/static/default/html/partials/modals.html
@@ -19,7 +19,7 @@
   <form id="form-contact-add" class="standard">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <button type="button" class="close button-secondary" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title"><span class="icon-groups"></span> {{_("Add Contact")}}</h4>
       </div>
       <div class="modal-body clearfix">


### PR DESCRIPTION
Currently the close button on the »Add Contact« dialog is emphasized in blue. This feels like too much of a focus on closing the window, especially because only the primary action should be emphasized like that – which is the »Add« button on the bottom right in this case.

cc @brennannovak :)
