### PR TITLE
Remove superfluous cancel button from new contact modal

### DIFF
--- a/static/default/html/partials/modals.html
+++ b/static/default/html/partials/modals.html
@@ -37,7 +37,6 @@
         <div id="contact-add-key"></div>
       </div>
       <div class="modal-footer">
-        <button title="{{_("Cancel")}}" class="left button-secondary" alt="{{_("Cancel")}}" data-dismiss="modal">{{_("Cancel")}}</button>
         <a id="contact-add-keysearch" title="{{_("Search for Keys")}}" alt="{{_("Search for Keys")}}" data-action="keysearch" class="button-alert">
           <span class="icon-key"></span> {{_("Search for Keys")}}
         </a>


### PR DESCRIPTION
The cancel button here is really not needed. It’s already possible to close the window by clicking the closing x in the top right, and clicking anywhere outside of the modal. An additional button just makes it seem like there’s more actions available.

cc @brennannovak :rocket:
