### PR TITLE
Move compose function more integrated into the sidebar

### DIFF
--- a/static/default/html/partials/sidebar.html
+++ b/static/default/html/partials/sidebar.html
@@ -39,6 +39,13 @@
 <div id="sidebar" class="comfy">
   <nav>
     <ul id="sidebar-priority" class="sidebar-sortable">
+      <li {% if command == "edit" %}class="navigation-on"{% endif %}>
+        <a href="#" id="button-compose" class="sidebar-tag color-08-green"
+          title="{{_("Compose")}}" alt="{{_("Compose")}}">
+          <span class="sidebar-icon icon-compose" style="color: #4b9441;"></span>
+          <span class="sidebar-name">{{_("Compose")}}</span>
+        </a>
+      </li>
       {%- for tag in mailpile("tags", "mode=tree", "display=priority").result.tags -%}
       {{ render_sidebar_tag(tag) }}
       {%- endfor -%}

--- a/static/default/html/partials/topbar.html
+++ b/static/default/html/partials/topbar.html
@@ -60,7 +60,6 @@
     <nav class="topbar-nav">
       <ul>
         <li class="nav-search"><a href="#" title="{{_("Search")}}"><span class="link-icon icon-search"></span></a></li>
-        <li {% if command == "edit" %}class="navigation-on"{% endif %}><a href="#" id="button-compose" title="{{_("Compose")}}" alt="{{_("Compose")}}"><span class="link-icon icon-compose"></span></a></li>
         <li {% if command == "contacts" %}class="navigation-on"{% endif %}><a href="/contacts/" title="{{_("Contacts")}}" alt="{{_("Contacts")}}"><span class="link-icon icon-user"></span></a></li>
         <li {% if state.command_url in ("/tags/", "/filter/list/") %}class="navigation-on"{% endif %}><a href="/tags/" title="{{_("Tags")}}" alt="{{_("Tags")}}"><span class="link-icon icon-tag"></span></a></li>
         <li {% if command == "page" %}class="navigation-on"{% endif %}><a class="donate" href="/page/donate/" title="{{_("Donate")}}" alt="{{_("Donate")}}"><span class="link-icon icon-donate"></span></a></li>


### PR DESCRIPTION
Compose is one of the most essential functions. Hence it feels strange that it’s just in the top bar where it kind of blends in with other options-like items.

Here’s how it will look when it’s in the sidebar as the first item. More present, always first in the list, and especially now it has the text attached to it to make clear what it is for.
(Maybe it also needs wording improvement on »Compose« but for now I just used what is there.)

@brennannovak what do you think?
