### PR TITLE
use of appdirs package, should fix issue #870

### DIFF
--- a/mailpile/config.py
+++ b/mailpile/config.py
@@ -1093,7 +1093,7 @@ class ConfigManager(ConfigDict):
 
         # Use platform-specific defaults
         # via https://github.com/ActiveState/appdirs
-        dirs = AppDirs("Mailpile")
+        dirs = AppDirs("Mailpile", "Mailpile ehf")
         return os.path.join(dirs.user_data_dir, profile)
 
     def __init__(self, workdir=None, rules={}):

--- a/mailpile/config.py
+++ b/mailpile/config.py
@@ -14,6 +14,7 @@ import ConfigParser
 from jinja2 import Environment, BaseLoader, TemplateNotFound
 from urllib import quote, unquote
 from urlparse import urlparse
+from appdirs import AppDirs
 
 from mailpile.crypto.streamer import DecryptingStreamer
 from mailpile.crypto.gpgi import GnuPG
@@ -1090,22 +1091,10 @@ class ConfigManager(ConfigDict):
             if os.path.exists(workdir) and os.path.isdir(workdir):
                 return workdir
 
-        # FIXME: the logic below should be rewritten to use the appdirs
-        #        python packages, as per issue #870
-
-        basedir = None
-        if sys.platform.startswith('win'):
-            # Obey Windows conventions (more or less?)
-            basedir = os.getenv('APPDATA', os.path.expanduser('~'))
-        elif sys.platform.startswith('darwin'):
-            # Obey Mac OS X conventions
-            basedir = os.path.expanduser('~/Library/Application Support')
-        else:
-            # Assume other platforms are Unixy
-            basedir = os.getenv('XDG_DATA_HOME',
-                                os.path.expanduser('~/.local/share'))
-
-        return os.path.join(basedir, 'Mailpile', profile)
+        # Use platform-specific defaults
+        # via https://github.com/ActiveState/appdirs
+        dirs = AppDirs("Mailpile")
+        return os.path.join(dirs.user_data_dir, profile)
 
     def __init__(self, workdir=None, rules={}):
         ConfigDict.__init__(self, _rules=rules, _magic=False)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ nose
 mock>=1.0.1
 pyDNS
 pgpdump
+appdirs

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ spambayes>=1.1b1
 markupsafe
 pyDNS
 pgpdump
+appdirs


### PR DESCRIPTION
Hi! (First of all, thanks for working on Mailpile, it looks really good, I'm looking forward to it becoming a little more stable so I can start recommending it to my non-technical friends!)

I saw issue #870 and thought it was a nice small task to start with contributing, as I don't have extensive experience with larger python projects. If you can suggest other smaller python-based issues I'm also happy to work on that.

Question: the AppDirs optionally has an `appauthor` field, which may be used on windows machines for the user data directory - what the official author name of Mailpile? "Mailpile-Team"?
