### PR TITLE
fix add/remove tags in pile_action_{,un}select

### DIFF
--- a/static/default/html/jsapi/search/ui.js
+++ b/static/default/html/jsapi/search/ui.js
@@ -10,7 +10,7 @@ Mailpile.pile_action_select = function(item) {
     Mailpile.bulk_cache_add('messages_cache', item.data('mid'));
 
     // Add Tags
-    var metadata = _.findWhere(Mailpile.instance.metadata, { mid: item.data('mid') });
+    var metadata = _.findWhere(Mailpile.instance.metadata, { mid: item.attr('data-mid') });
     if (metadata) {
       _.each(metadata.tag_tids, function(tid, key) {
         var tag = _.findWhere(Mailpile.instance.tags, { tid: tid });
@@ -41,7 +41,7 @@ Mailpile.pile_action_unselect = function(item) {
     Mailpile.bulk_cache_remove('messages_cache', item.data('mid'));
 
     // Remove Tags
-    var metadata = _.findWhere(Mailpile.instance.metadata, { mid: item.data('mid') });
+    var metadata = _.findWhere(Mailpile.instance.metadata, { mid: item.attr('data-mid') });
     _.each(metadata.tag_tids, function(tid, key) {
       var tag = _.findWhere(Mailpile.instance.tags, { tid: tid });
       if (tag.type === 'tag') {


### PR DESCRIPTION
Jquery try to be smart with data coming from html5 data-\* attributes [http://api.jquery.com/data/#data-html5] and return a numeric when mid looks like an int. This cause findWhere to not find metadata, ignoring add tags on select and crashing with metadata undefined in unselect.

I guess issues #901 and #886 are related to this.

I'm not sure about the other uses of .data('mid') (or any other "could be seen as numeric" ids)
