### PR TITLE
Exclude tests from install.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-exclude tests *

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ Mailpile is a tool for building and maintaining a tagging search
 engine for a personal collection of e-mail.  It can be used as a
 simple web-mail client.
 """,
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
     data_files=data_files,
     install_requires=[
         'lxml>=2.3.2',


### PR DESCRIPTION
Do not install tests in python_sitedir. See issue 425
