### PR TITLE
Replace colon escape sequences in GPG results (fixes #855)

### DIFF
--- a/mailpile/crypto/gpgi.py
+++ b/mailpile/crypto/gpgi.py
@@ -180,7 +180,7 @@ class GnuPGRecordParser:
         return self.keys
 
     def parse_line(self, line):
-        line = dict(zip(self.record_fields, line.strip().split(":")))
+        line = dict(zip(self.record_fields, map(lambda s: s.replace("\\x3a", ":"), line.strip().split(":"))))
         r = self.dispatch.get(line["record"], self.parse_unknown)
         r(line)
 


### PR DESCRIPTION
Results from GPG are colon-separated (and colons in the values are replaced with an escape sequence). Example result line:

$ gpg --list-keys --with-colons
pub:-:4096:1:XXXXXXXXXXXXXXXX:XXXX-XX-XX:::-:BNVK \x3a) hi@bnvk.me::scESC:

So when parsing the results, after splitting the result string at the colons, the escape sequences needs to be converted back to colons.

fixes  #855
