### PR TITLE
Update Dockerfile to use the new syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ RUN make debian-dev && apt-get clean
 ADD . /Mailpile
 
 # Setup
-RUN ./mp --setup
-RUN ./mp --set sys.http_host=0.0.0.0
+RUN ./mp setup
 
-CMD /Mailpile/mp www
+CMD /Mailpile/mp --www=0.0.0.0:33411 --wait
 EXPOSE 33411
-VOLUME /.mailpile
+VOLUME /.share/local/Mailpile


### PR DESCRIPTION
This changes the Dockerfile to use "setup" rather than "--setup" which changed recently. Also makes the mp binary wait so that Docker doesn't terminate after starting up.

Lastly, we change the directory structure to the new linux location

You can run this by doing this:

sudo docker run -i -d -v /mnt/mailpile-data/:/.local/share/Mailpile -v /mnt/mailpile-encryption:/.gnupg -p 33411:33411 -t Mailpile
