### PR TITLE
Fixing bug when on first page

### DIFF
--- a/static/default/html/jsapi/index.js
+++ b/static/default/html/jsapi/index.js
@@ -28,7 +28,7 @@ Mailpile = {
     ["normal", "g n t",  function() { Mailpile.go("/tag/add/"); }],
     ["normal", "g s",    function() { Mailpile.go("/settings/profiles/"); }],
     ["normal", "h",      function() { Mailpile.go("/help/"); }],
-    ["normal", "right",  function() { Mailpile.go($('#pile-next').attr('href')); }],
+    ["normal", "right",  function() { if ($('#pile-next').length) { Mailpile.go($('#pile-next').attr('href'));} }],
     ["normal", "left",   function() { if ($('#pile-previous').length) { Mailpile.go($('#pile-previous').attr('href'));} }],
     ["normal", "command+z ctrl+z",  function() { alert('Undo Something ') }],
     ["normal", "space",  function() { Mailpile.bulk_action_select_target(); }],


### PR DESCRIPTION
This makes sure that when you are on the first page the previous button wont be activated with keyboard.
