### PR TITLE
Increase timeout for resetting 'Test route' check link

### DIFF
--- a/static/default/html/jsapi/setup/sending.js
+++ b/static/default/html/jsapi/setup/sending.js
@@ -149,7 +149,7 @@ var SendingView = Backbone.View.extend({
           $('#setup-sending-check-auth')
             .removeClass('color-08-green color-12-red')
             .html('<a href="#" id="btn-setup-sending-check" class="setup-check-connection"><span class="icon-help"></span> {{_("Test Route")}}</a>');
-        }, 2000);
+        }, 5000);
     });
   },
   actionBack: function(e) {


### PR DESCRIPTION
2s is too little, and often disappears too soon. Increase to
5 seconds.

Ideally long term we wouldn't have it magically disappear - since the
test takes quite a while, and if you tab out and tab back it is going to
be confusing.
