### PR TITLE
Fix edit sidebar button

### DIFF
--- a/static/default/html/jsapi/ui/events.js
+++ b/static/default/html/jsapi/ui/events.js
@@ -18,7 +18,7 @@ $(document).on('click', '.button-sidebar-edit', function() {
   // Make Editable
   if ($(this).data('state') === 'done') {
 
-    Mailpile.UI.SidebarSortable();
+    Mailpile.UI.Sidebar.Sortable();
 
     // Disable Drag & Drop
     $('a.sidebar-tag').draggable({ disabled: true });


### PR DESCRIPTION
Click event for 'Edit Sidebar' tries to invoke `SidebarSortable` instead of `Sidebar.Sortable` resulting in `TypeError: Mailpile.UI.SidebarSortable is not a function` and an inability to edit.
