### PR TITLE
Don't ignore 'http' and 'https' while scanning

### DIFF
--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -47,7 +47,7 @@ PROSE_REGEXP = re.compile('[^\s!@#$%^&*\(\)_+=\{\}\[\]'
                           ':\"|;\'\\\<\>\?,\.\/\-]{1,}')
 
 STOPLIST = set(['an', 'and', 'are', 'as', 'at', 'by', 'for', 'from',
-                'has', 'http', 'https', 'i', 'in', 'is', 'it',
+                'has', 'i', 'in', 'is', 'it',
                 'mailto', 'me',
                 'og', 'or', 're', 'so', 'the', 'to', 'was', 'you'])
 


### PR DESCRIPTION
Remove http and https from common words: fixes empty results on links search. Note, that this would be applied to new messages only