### PR TITLE
Switching to tox and test-requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 mp-virtualenv
 .idea
 .*deps
+.tox
 mailpile.egg-info/
 mailpile-tmp.py
 mailpile/www/default/config.codekit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: python
-python:
-  - "2.7"
+python: 2.7
+env:
+  - TOX_ENV=py27
+
 before_install:
   - sudo apt-get update
-  - sudo apt-get install gnupg
-install:
-  - pip install -r requirements.txt --use-mirrors
-  - pip install coverage coveralls nose --use-mirrors
-script:
-  - "python setup.py install"
-  - "nosetests mailpile.tests --with-coverage --cover-package=mailpile"
-after_success:
-  - "coveralls"
+  - sudo apt-get install -y gnupg
 
+install:
+  - pip install tox coveralls
+
+script:
+  - tox -e $TOX_ENV
+
+after_success:
+  - coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+lxml>=2.3.2
+Jinja2
+spambayes>=1.1b1
+selenium>=2.40.0
+markupsafe
+nose
+mock>=1.0.1
+pyDNS
+pgpdump

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
-lxml>=2.3.2
-Jinja2
-spambayes>=1.1b1
-selenium>=2.40.0
-markupsafe
-nose
-mock>=1.0.1
-pyDNS
-pgpdump

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+selenium>=2.40.0
+mock>=1.0.1
+coverage
+nose

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ selenium>=2.40.0
 mock>=1.0.1
 coverage
 nose
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27
+
+[testenv]
+VIRTUAL_ENV={envdir}
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+commands = nosetests {toxinidir}/mailpile/tests --with-coverage --cover-package=mailpile


### PR DESCRIPTION
Allows for more consistent testing (CI and local) through the use of tox
controlled virtualenv's to execute your tests.

- Switched the Travis CI config to use the project's tox setup.

New way of executing your tests:
```
# If you need to install tox
pip install tox

# Execute tox
tox
```