### PR TITLE
Walk IMAP path

### DIFF
--- a/mailpile/mail_source/__init__.py
+++ b/mailpile/mail_source/__init__.py
@@ -452,7 +452,7 @@ class BaseMailSource(threading.Thread):
         path = path.replace('/.', '/')
         parts = ('/' in path) and path.split('/') or path.split('\\')
         parts = [p for p in parts if not re.match(self.BORING_FOLDER_RE, p)]
-        tagname = parts.pop(-1).split('.')[0]
+        tagname = parts.pop(-1).split('.')[-1]
 #       if self.my_config.name:
 #           tagname = '%s/%s' % (self.my_config.name, tagname)
         return CleanText(tagname.replace('_', ' '),

--- a/mailpile/mail_source/imap.py
+++ b/mailpile/mail_source/imap.py
@@ -639,17 +639,18 @@ class ImapMailSource(BaseMailSource):
         return len(discovered)
 
     def _walk_mailbox_path(self, conn, prefix):
+        """
+        Walks the IMAP path recursively and returns a list of all found
+        mailboxes.
+        """
         mboxes = []
         try:
             ok, data = self.timed_imap(conn.list, prefix, '%')
             while ok and len(data) >= 3:
                 (flags, sep, path), data[:3] = data[:3], []
-                if '[Gmail]' in path:
-                    # FIXME: Temp hack to ignore the [Gmail] thing
-                    continue
                 mboxes.append(self._fmt_path(path))
                 if '\\HasChildren' in flags:
-                    mbx_subtree = self._walk_mailbox_path(conn, '%s.' % (path))
+                    mbx_subtree = self._walk_mailbox_path(conn, '%s%s' % (path, sep))
                     mboxes.extend(mbx_subtree)
         except self.CONN_ERRORS:
             pass


### PR DESCRIPTION
This is a fix for #1105!

_Fixes:_
- ImapMailSource walks the IMAP path and discovers all mailboxes in the tree. Before, only root level mailboxes were listed.
- The '[Gmail]' mailbox is no longer ignored since all children are now listed as well.

_Remaining issues:_
- The auto-assignment of priority tags to mailboxes might need a work over. E.g. if the Mailbox prefix is 'INBOX', the Inbox tag is assigned to all children as well.

