### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,9 +4,10 @@ recursive-exclude scripts *
 recursive-exclude testing *
 recursive-include mailpile/tests/data *
 recursive-exclude mailpile/tests/data *~
-recursive-include mailpile/locales *.mo *.po *.pot
+recursive-include mailpile/locale *.mo *.po *.pot
 recursive-include mailpile/www *
 recursive-include mailpile/plugins *
+recursive-include mailpile/contrib *
 include Makefile
 include README.md
 include AGPLv3.txt


### PR DESCRIPTION
Fixed locale/locales typo
Added "recursive-include mailpile/contrib *"
Fixes contrib and locale directories not being added to package through setup.py