### PR TITLE
fix error-checking comparison bug

### DIFF
--- a/mailpile/mailutils.py
+++ b/mailpile/mailutils.py
@@ -1632,7 +1632,7 @@ class AddressHeaderParser(list):
                                                _raise=_raise)
                 return self
             except ValueError:
-                if _pass == 3 and _raise:
+                if _pass == '3' and _raise:
                     raise
         return self
 


### PR DESCRIPTION
"for _pass in ('2', '3'):" did not match with "if _pass == 3", but it does match with "if _pass == '3'".