### PR TITLE
Don't fail on unicode tags

### DIFF
--- a/mailpile/mail_source/__init__.py
+++ b/mailpile/mail_source/__init__.py
@@ -457,8 +457,8 @@ class BaseMailSource(threading.Thread):
         if save:
             self._save_config()
 
-    BORING_FOLDER_RE = re.compile('(?i)^(home|mail|data|user\S*|[^a-z]+)$')
-    TAGNAME_STRIP_RE = re.compile('[{}\\[\\]]')
+    BORING_FOLDER_RE = re.compile('(?i)^(home|mail|data|user\S*|[^[:alpha:]]+)$', re.UNICODE)
+    TAGNAME_STRIP_RE = re.compile('[{}\\[\\]]', re.UNICODE)
 
     def _path_to_tagname(self, path):  # -> tag name
         """This converts a path to a tag name."""


### PR DESCRIPTION
_path_to_tagname fails on non-latin scripts, (e.g. "Приоритетные", Russian variant for widely used "Important"), because of non-unicode regexps:

Traceback (most recent call last):
  File "/home/torkve/workspace/mailpile/mailpile/mail_source/__init__.py", line 753, in run
    self.sync_mail()
  File "/home/torkve/workspace/mailpile/mailpile/mail_source/__init__.py", line 180, in sync_mail
    stop_after=batch)
  File "/home/torkve/workspace/mailpile/mailpile/mail_source/__init__.py", line 647, in rescan_mailbox
    self._create_primary_tag(mbx_cfg)
  File "/home/torkve/workspace/mailpile/mailpile/mail_source/__init__.py", line 428, in _create_primary_tag
    mbx_cfg.primary_tag = self._create_tag_name(self._path(mbx_cfg))
  File "/home/torkve/workspace/mailpile/mailpile/mail_source/__init__.py", line 483, in _create_tag_name
    return self._unique_tag_name(self._path_to_tagname(path))
  File "/home/torkve/workspace/mailpile/mailpile/mail_source/__init__.py", line 468, in _path_to_tagname
    tagname = parts.pop(-1).split('.')[0]
IndexError: pop from empty list

Probably there're other places to fix too, but this very problem is fixed by this patch.