### PR TITLE
Removes "Re:" "Fw:" and so on on replies subjects

### DIFF
--- a/mailpile/plugins/compose.py
+++ b/mailpile/plugins/compose.py
@@ -377,6 +377,17 @@ class RelativeCompose(Compose):
     _TEXT_PARTTYPES = ('text', 'quote', 'pgpsignedtext', 'pgpsecuretext',
                        'pgpverifiedtext')
 
+    _FW_REGEXP = re.compile(r'^(fwd|fw):.*', re.IGNORECASE)
+    _RE_REGEXP = re.compile(r'^(rep|re):.*', re.IGNORECASE)
+
+    @staticmethod
+    def prefix_subject(subject, prefix, prefix_regex):
+        """Avoids stacking several consecutive Fw: Re: Re: Re:"""
+        if prefix_regex.match(subject):
+            return subject
+        else:
+            return '%s %s' % (prefix, subject)
+
 
 class Reply(RelativeCompose):
     """Create reply(-all) drafts to one or more messages"""
@@ -507,7 +518,8 @@ class Reply(RelativeCompose):
 
         return (Email.Create(idx, local_id, lmbox,
                              msg_text='\n\n'.join(msg_bodies),
-                             msg_subject=('Re: %s' % ref_subjs[-1]),
+                             msg_subject=cls.prefix_subject(
+                                 ref_subjs[-1], 'Re:', cls._RE_REGEXP),
                              msg_from=headers.get('from', None),
                              msg_to=headers.get('to', []),
                              msg_cc=headers.get('cc', []),
@@ -609,7 +621,8 @@ class Forward(RelativeCompose):
 
         email = Email.Create(idx, local_id, lmbox,
                              msg_text='\n\n'.join(msg_bodies),
-                             msg_subject=('Fwd: %s' % ref_subjs[-1]),
+                             msg_subject=cls.prefix_subject(
+                                 ref_subjs[-1], 'Fwd:', cls._FW_REGEXP),
                              msg_id=msgid,
                              msg_atts=msg_atts,
                              save=(not ephemeral),

--- a/mailpile/tests/__init__.py
+++ b/mailpile/tests/__init__.py
@@ -13,12 +13,15 @@ import mailpile.util
 from mailpile.plugins.tags import AddTag, Filter
 from mailpile.crypto.gpgi import GNUPG_HOMEDIR
 from mailpile.ui import SilentInteraction
+from mailpile.vcard import AddressInfo
 
 # Pull in all the standard plugins, plus the demos.
 from mailpile.mailboxes import *
 from mailpile.plugins import *
 
 MP = None
+MY_FROM = 'team+testing@mailpile.is'
+MY_NAME = 'Mailpile Team'
 
 
 def get_mailpile_root():
@@ -63,6 +66,7 @@ def _initialize_mailpile_for_testing(workdir, test_data):
 
     mp.add(test_data)
     mp.rescan('mailboxes')
+    mp.profiles_add(MY_FROM, '=', MY_NAME)
 
     return mp, session, config, ui
 

--- a/mailpile/tests/data/Maildir/cur/fw-question-1443197278.mbx
+++ b/mailpile/tests/data/Maildir/cur/fw-question-1443197278.mbx
@@ -1,0 +1,8 @@
+From nobody Fri Mar  7 15:17:43 2014
+Content-Type: text/plain; charset=UTF-8
+MIME-Version: 1.0
+Subject: Fw: About shrubberies
+From: you@test.local
+To: another@test.local
+
+Test

--- a/mailpile/tests/data/Maildir/cur/mailpile-1400069992.mbx
+++ b/mailpile/tests/data/Maildir/cur/mailpile-1400069992.mbx
@@ -34,7 +34,7 @@ To: hi@wigglebot.com
 Cc: cash@square.com
 X-DynectEmail-Msg-Key: 20140514011619.FF8A06700036@mail6-12-ewr
 Message-ID:  <f38s7nk064or5h7pjjwzsj4kt-a881f968-36a7-4af7-b027-a12d6b686326@square.com>
-Subject: Here's $1
+Subject: Re: Here's $1
 MIME-Version: 1.0
 Content-Type: multipart/alternative;  boundary="----=_Part_31399_1772714090.1400030175154"
 X-Square-Cash-Referrer-Token: C_apf4xbdgjbf39ema8ie8noen3

--- a/mailpile/tests/test_command.py
+++ b/mailpile/tests/test_command.py
@@ -71,6 +71,46 @@ class TestCommands(MailPileUnittest):
         self.assertEqual(res.as_dict()["result"]['crypto-policy'],
                          'best-effort')
 
+    def test_reply_subjects_on_first_msg(self):
+        # Subject: Verb. Target. Outcome.'
+        mid = self.mp.search('subject:Verb').result['data']['metadata']\
+                                            .values()[0]['mid']
+        res = self.mp.reply('ephemeral', '=%s' % mid)
+        self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
+                         'Re: Verb. Target. Outcome.')
+
+    def test_reply_subject_on_reply_msg(self):
+        # Subject: Re: Here's $1
+        mid = self.mp.search('subject:Here').result['data']['metadata']\
+                                            .values()[0]['mid']
+        res = self.mp.reply('ephemeral', '=%s' % mid)
+        self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
+                         "Re: Here's $1")
+
+    def test_reply_subject_on_fw_msg(self):
+        # Subject: Fw: About shrubberies
+        mid = self.mp.search('shrubberies').result['data']['metadata']\
+                                           .values()[0]['mid']
+        res = self.mp.reply('ephemeral', '=%s' % mid)
+        self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
+                         "Re: Fw: About shrubberies")
+
+    def test_fwd_subject_on_re_msg(self):
+        # Subject: Re: Here's $1
+        mid = self.mp.search('subject:Here').result['data']['metadata']\
+                                            .values()[0]['mid']
+        res = self.mp.forward('ephemeral', '=%s' % mid)
+        self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
+                         "Fwd: Re: Here's $1")
+
+    def test_fw_subject_on_fw_msg(self):
+        # Subject: Fw: A question shrubberies
+        mid = self.mp.search('shrubberies').result['data']['metadata']\
+                                           .values()[0]['mid']
+        res = self.mp.forward('ephemeral', '=%s' % mid)
+        self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
+                         "Fw: About shrubberies")
+
 
 class TestCommandResult(MailPileUnittest):
     def test_command_result_as_dict(self):

--- a/mailpile/tests/test_search.py
+++ b/mailpile/tests/test_search.py
@@ -21,7 +21,7 @@ def checkSearch(query, expected_count=1):
 
 def test_generator():
     # All mail
-    yield checkSearch(['all:mail'], 9)
+    yield checkSearch(['all:mail'], 10)
     # Full match
     yield checkSearch(['brennan'])
     # Partial match


### PR DESCRIPTION
That PR is a work-in-progress, please don't merge it yet : it's working for reply subjects, but not yet for forwards.

To go further, I need help on how to properly add a default profile to the testing environment (in `tests/__init__.py`). @BjarniRunar ?

Also, that's my very first commit on mp's code, so any input is appreciated, especially about design choices.

Among others, I'm not totally confortable with using the jinja helper to do the job... but it does exactly the required job.

Thanks by advance.