### PR TITLE
Prevent browsers leaking referrer headers

### DIFF
--- a/mailpile/www/default/html/partials/head.html
+++ b/mailpile/www/default/html/partials/head.html
@@ -1,4 +1,5 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="referrer" content="no-referrer" />
   <link rel="stylesheet" href="{{ U('/static/css/default.css') }}" />
   <link rel="stylesheet" href="{{ U('/static/css/print.css') }}" media="print" />
   {% if state.command_url not in ("/auth/login/", "/auth/logout/") %}


### PR DESCRIPTION
This change is to prevent browsers sending Referrer headers from Mailpile.

It fixes the scenario where the user clicks a link in a plain-text email and their browser sends a link pointing to their Mailpile instance (and thread ID) to an external site. I see that HTML emails are already contained in a sourceless iframe and don't leak referrers—that's great!

The meta tag used here is part of the [Referrer Policy spec](https://w3c.github.io/webappsec/specs/referrer-policy/) and already works in Chrome and Firefox.

Thanks for working on Mailpile!