### PR TITLE
Avoid passing unicode to imaplib during login

### DIFF
--- a/mailpile/mail_source/imap.py
+++ b/mailpile/mail_source/imap.py
@@ -683,9 +683,9 @@ class ImapMailSource(BaseMailSource):
 
             try:
                 ok, data = self.timed_imap(conn.login,
-                                           my_config.username,
-                                           my_config.password)
-            except IMAP4.error:
+                                           my_config.username.encode('utf-8'),
+                                           my_config.password.encode('utf-8'))
+            except IMAP4.error, UnicodeDecodeError:
                 ok = False
             if not ok:
                 ev['error'] = ['auth', _('Invalid username or password')]


### PR DESCRIPTION
The imaplib library in python 2.7.9 does not automatically quote unicode types: https://hg.python.org/cpython/file/2.7/Lib/imaplib.py#l1069, so the user gets an 'Invalid username or password' error if his IMAP username contains a slash or any other character requiring the string to be quoted. This is because the username in the configuration is of type unicode.

Here's an example session showing the failure in imaplib when logging into an exchange server through DavMail:

```python
$ python
Python 2.7.9 (default, Apr  2 2015, 15:33:21)
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import imaplib
>>> from getpass import getpass
>>> m = imaplib.IMAP4('localhost', 1143)
>>> m.login('AD\\perriv', getpass())
Password:
('OK', ['Authenticated'])
>>> m = imaplib.IMAP4('localhost', 1143)
>>> m.login(u'AD\\perriv', getpass())
Password:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/imaplib.py", line 520, in login
    raise self.error(dat[-1])
imaplib.error: LOGIN failed
```

Based off of the code that went into https://github.com/mailpile/Mailpile/commit/422aff53c919ca791bd29a4257acab5982298df2 that fixed #903.