### PR TITLE
Fix typo: Current Passphrase

### DIFF
--- a/mailpile/www/default/html/setup/partials/passphrase.html
+++ b/mailpile/www/default/html/setup/partials/passphrase.html
@@ -4,7 +4,7 @@
   <p>{{_("Your passphrase is what you use to login to your Mailpile")}}</p>
   <form id="form-setup-keys" class="standard">
     <span id="validation-existing">
-      <label>{{_("Current Prassphrase")}}</label>
+      <label>{{_("Current Passphrase")}}</label>
       <input id="input-setup-passphrase" class="medium center" type="password" name="passphrase" autofocus autocorrect="off" autocapitalize="off" placeholder="top secret super duper passphrase" tabindex="2">
     </span>
     <span id="validation-passphrase">


### PR DESCRIPTION
Minor typo fixed: "Current Prassphrase" -> "Current Passphrase"

This does not rebuild translation strings as I noticed that more changes to strings had been made so I wanted to leave that to you (the maintainers) to decide when to push or ask me to do it.

This closes #1382 