### PR TITLE
debian-dev: add 'node' to list of packages to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ fedora-dev:
 debian-dev:
 	sudo apt-get install python-imaging python-lxml python-jinja2 pep8 \
 	                     ruby-dev yui-compressor python-nose spambayes \
-	                     phantomjs python-pip python-mock npm
+	                     phantomjs python-pip python-mock npm node
 	if [ "$(shell cat /etc/debian_version)" = "jessie/sid"  ]; then\
 		sudo apt-get install rubygems-integration;\
 	else \


### PR DESCRIPTION
node is needed to run make js (and thus make all)