### PR TITLE
Fix/improve arch-dev target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ arch-dev:
 	cd $$TMPDIR; \
 	pacman -Qs '^yuicompressor$$' > /dev/null; \
 	if [ $$? -ne 0 ]; then \
-	  curl -s https://aur.archlinux.org/packages/yu/yuicompressor/yuicompressor.tar.gz | tar xzv; \
+	  curl -s https://aur.archlinux.org/cgit/aur.git/snapshot/yuicompressor.tar.gz | tar xzv; \
 	  cd yuicompressor; \
 	  makepkg -si; \
 	  cd $$TMPDIR; \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ arch-dev:
 	cd $$TMPDIR; \
 	pacman -Qs '^yuicompressor$$' > /dev/null; \
 	if [ $$? -ne 0 ]; then \
+	  sudo pacman -S --needed core/base-devel; \
 	  curl -s https://aur.archlinux.org/cgit/aur.git/snapshot/yuicompressor.tar.gz | tar xzv; \
 	  cd yuicompressor; \
 	  makepkg -si; \

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ dev:
 	@echo export PYTHONPATH=`pwd`
 
 arch-dev:
-	sudo pacman -Syu community/python2-pillow extra/python2-lxml community/python2-jinja \
+	sudo pacman -Syu --needed community/python2-pillow extra/python2-lxml community/python2-jinja \
 	                 community/python2-pep8 extra/python2-nose community/phantomjs \
 	                 extra/python2-pip community/python2-mock \
-	                 extra/ruby
+	                 extra/ruby community/npm
 	TMPDIR=`mktemp -d /tmp/aur.XXXXXXXXXX`; \
 	cd $$TMPDIR; \
 	pacman -Qs '^yuicompressor$$' > /dev/null; \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ arch-dev:
 	sudo pacman -Syu --needed community/python2-pillow extra/python2-lxml community/python2-jinja \
 	                 community/python2-pep8 extra/python2-nose community/phantomjs \
 	                 extra/python2-pip community/python2-mock \
-	                 extra/ruby community/npm
+	                 extra/ruby community/npm community/spambayes
 	TMPDIR=`mktemp -d /tmp/aur.XXXXXXXXXX`; \
 	cd $$TMPDIR; \
 	pacman -Qs '^yuicompressor$$' > /dev/null; \
@@ -28,12 +28,6 @@ arch-dev:
 	  cd yuicompressor; \
 	  makepkg -si; \
 	  cd $$TMPDIR; \
-	fi; \
-	  pacman -Qs '^spambayes$$' > /dev/null; \
-	  if [ $$? -ne 0 ]; then \
-	  curl -s https://aur.archlinux.org/packages/sp/spambayes/spambayes.tar.gz | tar xzv; \
-	  cd spambayes; \
-	  makepkg -si; \
 	fi; \
 	cd /tmp; \
 	rm -rf $$TMPDIR


### PR DESCRIPTION
* add --needed to pacman command to only install packages that are not already present
* add npm to pacman dependencies
* install spambayes via pacman (instead of AUR) since it's available in the repositories now
* fix URL for yuicompressor
* install base-dev before compiling yuicompressor (if not already present)

NOTE: one may also want to use the nodejs LESS compiler instead of the ruby LESS compiler since that's already in the arch repositories (and maybe even removes the ruby dependencies?). I don't know if the ruby compiler is better than the nodejs version…