### PR TITLE
Install bower dependencies before building less

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ less-loop: less-compiler
         done
 
 less-compiler:
+	bower install
 	@cp scripts/less-compiler.in scripts/less-compiler.mk
 	@find mailpile/www/default/less/ -name '*.less' \
                 |perl -npe s'/^/\t/' \


### PR DESCRIPTION
That's required because of less-elements dependency.