### PR TITLE
Fix copy/paste from mail body in thread view

### DIFF
--- a/mailpile/www/default/html/partials/thread_message.html
+++ b/mailpile/www/default/html/partials/thread_message.html
@@ -55,13 +55,13 @@
           {% autoescape false %}
           {% set part_text = part.data|nice_text|e|urlize|fix_urls(40, url_danger) %}
           {% if part.type in ("text", "pgpsignedtext") %}
-            <div class="thread-item-text">{{ part_text }}</div>
+            <div class="thread-item-text">{{ part_text|to_br }}</div>
           {% elif part.type in ("pgptext",) %}
             {% if part.crypto.encryption.status in ("lockedkey", "missingkey", "error") %}
               {%- set failed_crypto = part.crypto.encryption %}
               {%- include("partials/thread_message_cryptofail.html") %}
             {% else %}
-            <div class="thread-item-text">{{ part_text }}</div>
+            <div class="thread-item-text">{{ part_text|to_br }}</div>
             {% endif %}
           {% elif part.type in ("pgpbegin", "pgpend") %}
             <div class="thread-item-{{part.type}} hide">{{part.data}}</div>
@@ -71,17 +71,17 @@
             {%- if loop.index == (loop.length - 1) and
                    message.text_parts[last_part].type in ("signature", "quote") -%}
               {% do special_text_parts.append("quote") %}
-              <div class="thread-item-quote hide">{{ part_text }}</div>
+              <div class="thread-item-quote hide">{{ part_text|to_br }}</div>
             {# If this part is a quote at end of message, hide #}
             {% elif loop.last %}
               {% do special_text_parts.append("quote") %}
-              <div class="thread-item-quote hide">{{ part_text }}</div>
+              <div class="thread-item-quote hide">{{ part_text|to_br }}</div>
             {% else %}
-              <div class="thread-item-quote">{{ part_text }}</div>
+              <div class="thread-item-quote">{{ part_text|to_br }}</div>
             {%- endif -%}
           {% elif part.type == "signature" %}
             {% do special_text_parts.append("signature") %}
-            <div class="thread-item-signature hide">{{ part_text }}</div>
+            <div class="thread-item-signature hide">{{ part_text|to_br }}</div>
           {% else %}
             <div class="thread-item-text"><em>{{_("Unknown Text Part")}}</em></div>
           {% endif %}

--- a/mailpile/www/jinjaextensions.py
+++ b/mailpile/www/jinjaextensions.py
@@ -9,7 +9,7 @@ import shlex
 import time
 from jinja2 import nodes, UndefinedError, Markup
 from jinja2.ext import Extension
-from jinja2.utils import contextfunction, import_string
+from jinja2.utils import contextfunction, import_string, escape
 
 #from markdown import markdown
 
@@ -95,6 +95,10 @@ class MailpileCommand(Extension):
         # Strip trailing blank lines from email
         e.globals['nice_text'] = s._nice_text
         e.filters['nice_text'] = s._nice_text
+
+        # Transforms \n into HTML <br />
+        e.globals['to_br'] = s._to_br
+        e.filters['to_br'] = s._to_br
 
         # Strip Re: Fwd: from subject lines
         e.globals['nice_subject'] = s._nice_subject
@@ -645,6 +649,17 @@ class MailpileCommand(Extension):
                 else:
                     previous = 'blank'
         return trimmed.strip()
+
+    _TEXT_LINEBREAK_RE = re.compile(r'(?:\r\n|\r|\n)')
+
+    @classmethod
+    def _to_br(self, text):
+        """ Replaces \n by <br />
+
+        Inspired from http://jinja.pocoo.org/docs/dev/api/#custom-filters
+        """
+        result = '<br />'.join(p for p in self._TEXT_LINEBREAK_RE.split(escape(text)))
+        return Markup(result)
 
     @classmethod
     def _nice_subject(self, metadata):


### PR DESCRIPTION
Implemented using `<br />` for displaying line returns instead of relying on
`white-space: pre-wrap` for plaintext mail rendering.

Thread rendering is exactly the same than before (pixel-level checked), except,
copy/paste will now preserve line breaks in pasted text.

Could seem relevant to implement this fix with `<p>` instead of `<br />` but it
doesn't give the exact same rendering.