### PR TITLE
Removed tooltip animation hovering a message tag

### DIFF
--- a/mailpile/www/default/html/jsapi/search/tooltips.js
+++ b/mailpile/www/default/html/jsapi/search/tooltips.js
@@ -30,7 +30,8 @@ Mailpile.Search.Tooltips.MessageTags = function() {
       my: 'bottom center',
       at: 'top left',
       viewport: $(window),
-      adjust: {x: 7, y: 2}
+      adjust: {x: 7, y: 2},
+      effect: false
     },
     show: { delay: 100 },
     hide: { fixed: true, delay: 350 }


### PR DESCRIPTION
In search view, qtip2 has a default to position the tooltip with an animation
from "default" to "choosen" position. That's weird.
Thanks http://stackoverflow.com/a/26672882/1377500

fix #1427