### PR TITLE
Fix extra +1 in per-thread count in we UI

### DIFF
--- a/mailpile/www/default/html/partials/search_item.html
+++ b/mailpile/www/default/html/partials/search_item.html
@@ -5,7 +5,7 @@
 %}{%  endif
 %}{%  set metadata = result.data.metadata[mid]
 %}{%  set thread = result.data.threads[metadata.thread_mid]
-%}{%  set conversation_count = thread|length + 1
+%}{%  set conversation_count = thread|length
 %}{%  set from = result.data.addresses[metadata.from.aid]
 %}{%  if not from
 %}{%    set from = {'fn': 'Unknown sender', 'email': ''}


### PR DESCRIPTION
It fixes most of the counting issues in web interface (except where there is a ghost message involved, see #1450).

I'm not sure that it's the right fix, because the tests are still yelling on more low-level code about counting, but however, if the "+1" is kept, It should IMHO be explained in a template comment because it looks weird.