### PR TITLE
prevent double ssl wrap to ensure ISPDB info is properly retrieved within sensible timeout

### DIFF
--- a/mailpile/conn_brokers.py
+++ b/mailpile/conn_brokers.py
@@ -47,7 +47,12 @@ except ImportError:
 
 org_cconn = socket.create_connection
 org_sslwrap = ssl.wrap_socket
-org_context_wrap_socket = ssl.SSLContext.wrap_socket
+try:
+    org_context_wrap_socket = ssl.SSLContext.wrap_socket
+    have_ssl_context = True
+except AttributeError:
+    org_context_wrap_socket = None
+    have_ssl_context = False
 
 monkey_lock = threading.RLock()
 
@@ -409,6 +414,8 @@ class BaseConnectionBrokerProxy(TcpConnectionBroker):
     def _wrap_ssl(self, conn):
         if self._debug is not None:
             self._debug('%s: Wrapping socket with SSL' % (self, ))
+        # FIXME: We're losing the SNI stuff here, which is super lame.
+        #        We should on Python 2.7.9+ try to fix that somehow.
         return org_sslwrap(conn, None, None, ssl_version=self.SSL_VERSION)
 
     def _create_connection(self, context, address, *args, **kwargs):
@@ -553,17 +560,17 @@ if __name__ != "__main__":
             return sock
         return org_sslwrap(sock, *args, **kwargs)
 
-    def SslContextWrapOnlyOnce(self, sock, *args, **kwargs):
-        """
-        Since we like to wrap things our own way, this make ssl.wrap_socket
-        into a no-op in the cases where we've alredy wrapped a socket.
-        """
-        if isinstance(sock, ssl.SSLSocket):
-            return sock
-        return org_context_wrap_socket(self, sock, *args, **kwargs)
-
     ssl.wrap_socket = SslWrapOnlyOnce
-    ssl.SSLContext.wrap_socket = SslContextWrapOnlyOnce
+
+    if have_ssl_context:
+        # Same again with SSLContext, if we have it.
+
+        def SslContextWrapOnlyOnce(self, sock, *args, **kwargs):
+            if isinstance(sock, ssl.SSLSocket):
+                return sock
+            return org_context_wrap_socket(self, sock, *args, **kwargs)
+
+        ssl.SSLContext.wrap_socket = SslContextWrapOnlyOnce
 
 else:
     import doctest

--- a/mailpile/conn_brokers.py
+++ b/mailpile/conn_brokers.py
@@ -47,6 +47,7 @@ except ImportError:
 
 org_cconn = socket.create_connection
 org_sslwrap = ssl.wrap_socket
+org_context_wrap_socket = ssl.SSLContext.wrap_socket
 
 monkey_lock = threading.RLock()
 
@@ -552,7 +553,17 @@ if __name__ != "__main__":
             return sock
         return org_sslwrap(sock, *args, **kwargs)
 
+    def SslContextWrapOnlyOnce(self, sock, *args, **kwargs):
+        """
+        Since we like to wrap things our own way, this make ssl.wrap_socket
+        into a no-op in the cases where we've alredy wrapped a socket.
+        """
+        if isinstance(sock, ssl.SSLSocket):
+            return sock
+        return org_context_wrap_socket(self, sock, *args, **kwargs)
+
     ssl.wrap_socket = SslWrapOnlyOnce
+    ssl.SSLContext.wrap_socket = SslContextWrapOnlyOnce
 
 else:
     import doctest

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -559,6 +559,9 @@ class SetupGetEmailSettings(TestableWebbable):
                 result['routes'].sort(key=self._rank)
                 return result
         except (IOError, ValueError, AttributeError):
+            # don't forget to delete this
+            # import traceback
+            # traceback.print_exc()
             return None
 
     def _get_ispdb(self, email, domain):
@@ -886,7 +889,7 @@ class SetupGetEmailSettings(TestableWebbable):
         self.deadline = time.time() + float(self.data.get('timeout', [10])[0])
         self.tracking_id = self.data.get('track-id', [None])[0]
         self.password = self.data.get('password', [None])[0]
-        emails = list(self.args) + self.data.get('email')
+        emails = list(self.args) + self.data.get('email', [])
         if self.password and len(emails) != 1:
             return self._error(_('Can only test settings for one account '
                                  'at a time'))

--- a/mailpile/www/default/html/profiles/account-form.html
+++ b/mailpile/www/default/html/profiles/account-form.html
@@ -155,7 +155,7 @@
             });
             Mailpile.API.setup_email_servers_get({
               'track-id': new_src_id,
-              'timeout': 120,
+              'timeout': 120000,
               'password': $(pf + '.fpa-basic-password').val(),
               'email': email
             }, function(data) {


### PR DESCRIPTION
the python 2.7.9/10 thing with the ssl/tls wrapping in the connection broker
some matching list data type thing from ages ago
and the seconds -> milliseconds timeout adjustment