### PR TITLE
locate mailpile executable with distutils.spawn

### DIFF
--- a/scripts/mailpile-admin.py
+++ b/scripts/mailpile-admin.py
@@ -8,6 +8,7 @@
 #
 import argparse
 import cgi
+import distutils.spawn
 import getpass
 import json
 import os
@@ -196,7 +197,7 @@ def get_os_settings(args):
         'apache-user': args.apache_user or 'www-data',
         'apache-group': args.apache_group or 'www-data',
         'webroot': args.webroot,
-        'mailpile': os.path.join(mp_root, 'mp'),
+        'mailpile': (distutils.spawn.find_executable('mailpile') or os.path.join(mp_root, 'mp')),
         'mailpile-root': mp_root,
         'mailpile-admin': os.path.realpath(sys.argv[0]),
         'mailpile-static': os.path.join(mp_root, 'mailpile', 'www', 'default'),


### PR DESCRIPTION
The executable should be ```mailpile```, and will be in ```/usr/bin/mailpile```, not in mp_root.

I am still leaving the mp_root option for development purposes.