### PR TITLE
Don't run FIX_PERMS_SCRIPT when not needed

### DIFF
--- a/scripts/mailpile-admin.py
+++ b/scripts/mailpile-admin.py
@@ -397,7 +397,6 @@ def start_mailpile(app_args, args):
                                user_settings['port'],
                                False, None, None)
         save_htaccess(args, os_settings, mailpiles)
-        run_script(args, os_settings, FIX_PERMS_SCRIPT)
 
 
 def stop_mailpile(app_args, args):


### PR DESCRIPTION
We shouldn't have to run FIX_PERMS_SCRIPT here.

Even if we did, we are going to get permissions denied because there is no point in trying to gain ownership to files that are not already ours.