### PR TITLE
/usr/share/mailpile/: Dont FollowSymLinks

### DIFF
--- a/packages/apache/mailpile.conf
+++ b/packages/apache/mailpile.conf
@@ -24,7 +24,6 @@ RewriteMap mailpileuser2hostport "txt:/var/lib/mailpile/apache/usermap.txt"
 
 <Directory "/usr/share/mailpile/">
     AllowOverride All
-    Options FollowSymLinks
     LogLevel alert rewrite:trace8
     Require all granted
 </Directory>


### PR DESCRIPTION
Even in dev mode, the directory itself is a symlink but nothing in its content is, so we don't need FollowSymLinks.