### PR TITLE
check that we are running from a virtual env AND installed in it

### DIFF
--- a/mailpile/config.py
+++ b/mailpile/config.py
@@ -1237,9 +1237,11 @@ class ConfigManager(ConfigDict):
         if env_share is not None:
             return env_share
 
-        # Check if we have been installed in a virtual env
+        # Check if we are running in a virtual env
         # http://stackoverflow.com/questions/1871549/python-determine-if-running-inside-virtualenv
-        if hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix'):
+        # We must also check that we are installed in the virtual env,
+        # not just that we are running in a virtual env.
+        if (hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix')) and __file__.startswith(sys.prefix):
             return os.path.join(sys.prefix, 'share', 'mailpile')
 
         # Check if we've been installed to /usr/local (or equivalent)

--- a/shared-data/multipile/mailpile-admin.py
+++ b/shared-data/multipile/mailpile-admin.py
@@ -314,9 +314,11 @@ def get_mailpile_shared_datadir():
     if env_share is not None:
         return env_share
 
-    # Check if we have been installed in a virtual env
-    # http://stackoverflow.com/questions/1871549/python-determine-if-running-insi
-    if hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix'):
+    # Check if we are running in a virtual env
+    # http://stackoverflow.com/questions/1871549/python-determine-if-running-inside-virtualenv
+    # We must also check that we are installed in the virtual env,
+    # not just that we are running in a virtual env.
+    if (hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix')) and __file__.startswith(sys.prefix):
         return os.path.join(sys.prefix, 'share', 'mailpile')
 
     # Check if we've been installed to /usr/local (or equivalent)


### PR DESCRIPTION
closes #1526

Checking that we executing in a virtual env is not enough to assume that we are installed in a virtual env. It could be that we are only using the venv to run dependencies that and we are running from the repository itself (as we do in the Getting Started in the wiki).