### PR TITLE
Moved mailpile-admin inside python module [WIP]

### DIFF
--- a/shared-data/multipile/mailpile-admin.py
+++ b/shared-data/multipile/mailpile-admin.py
@@ -357,7 +357,8 @@ def get_os_settings(args):
         'webroot': args.webroot,
         'rewritemap': args.rewritemap,
         'mailpile': (args.mailpile
-                     or distutils.spawn.find_executable('mailpile')
+                     or distutils.spawn.find_executable(
+                         'mailpile', os.path.join(sys.prefix, 'bin') + ':' + os.environ.get('PATH'))
                      or os.path.join(mp_root, 'mp')),
         'mailpile-admin': os.path.realpath(sys.argv[0]),
         'mailpile-theme': (args.mailpile_theme


### PR DESCRIPTION
Work in progress, not fully tested. Just opening the PR so that you know what I'm doing and don't move around those files for now.

This PR is an attempt at solving a few things:

- fix ```get_mailpile_shared_datadir```: It didn't work because ```__file__``` no longer refers to something within the mailpile install. We can't use it to find mailpile.
- remove ```get_mailpile_shared_datadir``` code duplication
- include mailpile-admin in the PATH (as requested)


This PR allows us to run multipile from a virtual env:
```
virtualenv env
source env/bin/activate
pip install -r requirements.txt
mailpile-admin --configure-apache
```

We can also run multipile from /usr/local:
```
sudo python setup.py install
mailpile-admin --configure-apache
```

Edit: The last thing that I would like to do is find a way to let users run multipile directly from the repository.