### PR TITLE
Windows-friendly CatchUnixSignals

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -40,9 +40,12 @@ def CatchUnixSignals(session):
 
     try:
         import signal
-        signal.signal(signal.SIGTERM, quit_app)
-        signal.signal(signal.SIGQUIT, quit_app)
-        signal.signal(signal.SIGUSR1, reload_app)
+        if os.name != 'nt':
+            signal.signal(signal.SIGTERM, quit_app)
+            signal.signal(signal.SIGQUIT, quit_app)
+            signal.signal(signal.SIGUSR1, reload_app)
+        else:
+            signal.signal(signal.SIGTERM, quit_app)
     except ImportError:
         pass
 


### PR DESCRIPTION
signal.SIGQUIT, signal.SIGUSR1 are not available on nt systems so it crashes on launch. This allows mailpile to launch