### PR TITLE
Fix config.py typo

### DIFF
--- a/mailpile/config.py
+++ b/mailpile/config.py
@@ -2314,8 +2314,8 @@ class ConfigManager(ConfigDict):
                                                      config.background)
                 config.save_worker.start()
             if not config.cron_worker:
-                self.cron_worker = Cron(
-                    self.cron_schedule, 'Cron worker', self.background)
+                config.cron_worker = Cron(
+                    config.cron_schedule, 'Cron worker', config.background)
                 config.cron_worker.start()
             if not config.http_worker:
                 start_httpd(httpd_spec)


### PR DESCRIPTION
That typo prevents mailpile-tests.py to suceed (and possibly cron stuff to work).