### PR TITLE
dont run make clean in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,14 +70,6 @@ APPVER = '%s%s' % (next(
 ).split('"')[1], BRANCHVER)
 
 
-## Cleanup ###################################################################
-try:
-    assert(0 == subprocess.call(['make', 'clean'], cwd=here))
-except:
-    print "Faild to run 'make clean'. Bailing out."
-    exit(1)
-
-
 ## Install ###################################################################
 
 class Builder(build_py):


### PR DESCRIPTION
this interferes with my work.

For example, make clean removes the locales, which I am trying to install.
It also removes the bower_components files, which I may want to keep if I am another distro than Debian and want to embed the javascript.

You may want to move things in the mrproper target instead, but  I think its easier to leave it up to whoever is installing.