### PR TITLE
Moved things out of clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,18 +97,18 @@ pytests:
 	@echo
 
 clean:
-	@rm -rf shared-data/locale/?? shared-data/locale/??[_@]*
 	@rm -f `find . -name \\*.pyc` \
 	       `find . -name \\*.mo` \
 	        mailpile-tmp.py mailpile.py \
 	        ChangeLog AUTHORS \
 	        .appver MANIFEST .SELF .*deps \
 	        scripts/less-compiler.mk ghostdriver.log
-	@rm -rf *.egg-info build/ mp-virtualenv/ bower_components/ \
+	@rm -rf *.egg-info build/ mp-virtualenv/ \
                mailpile/tests/data/tmp/ testing/tmp/
 	@rm -f shared-data/multipile/www/admin.cgi
 
 mrproper: clean
+	@rm -rf shared-data/locale/?? shared-data/locale/??[_@]*
 	@rm -rf dist/ bower_components/ shared-data/locale/mailpile.pot
 	git reset --hard && git clean -dfx
 


### PR DESCRIPTION
this interferes with my work.

Setup.py calls ```make clean```, so locales are deleted.

Also, I'm calling clean during packaging and it removes bower_components files, which are included in the tarball and I may want to keep if I decide to embed a library.

And now that I think about it, I think ```git reset --hard && git clean -dfx``` in mrproper is kinda dangerous. We should replace it with something else in a future PR.