### PR TITLE
added tests for decode_header and FormatMbxId

### DIFF
--- a/mailpile/tests/test_mailutils.py
+++ b/mailpile/tests/test_mailutils.py
@@ -1,11 +1,33 @@
+# -*- coding: utf-8 -*-
 import unittest
 
 import mailpile
 from mailpile.tests import MailPileUnittest
 from mailpile.mailutils import decode_header
+from mailpile.mailutils import FormatMbxId
 
 
 class TestCommands(MailPileUnittest):
     def test_decode_header_no_encoding(self):
         res = decode_header("olmsted")
         self.assertEqual(res, [('olmsted', None)])
+
+    def test_decode_header_encoded_valid1(self):
+        res = decode_header("=?charset?q?Hello_World?=")
+        self.assertEqual(res, [('Hello World', 'charset')])
+
+    def test_decode_header_encoded_valid2(self):
+        res = decode_header("=?\u?q?Hello_World?=")
+        self.assertEqual(res, [('Hello World', '\\u')])
+
+    def test_FormatMbxId_string_len_less_than_four(self):
+        res = FormatMbxId("a")
+        self.assertEqual(res, "000a")
+
+    def test_FormatMbxId_string_len_four(self):
+        res = FormatMbxId("abcd")
+        self.assertEqual(res, "abcd")
+
+    def test_FormatMbxId_unicode(self):
+        res = FormatMbxId('Ţ¼')
+        self.assertEqual(res, "\xc5\xa2\xc2\xbc")        

--- a/mailpile/tests/test_mailutils.py
+++ b/mailpile/tests/test_mailutils.py
@@ -5,6 +5,7 @@ import mailpile
 from mailpile.tests import MailPileUnittest
 from mailpile.mailutils import decode_header
 from mailpile.mailutils import FormatMbxId
+from mailpile.mailutils import MakeContentID
 
 
 class TestCommands(MailPileUnittest):
@@ -40,3 +41,7 @@ class TestCommands(MailPileUnittest):
     def test_FormatMbxId_unicode(self):
         res = FormatMbxId('Ţ¼')
         self.assertEqual(res, "\xc5\xa2\xc2\xbc")
+
+    def test_MakeContentID(self):
+        res = MakeContentID()
+        self.assertEqual(len(res), 7)

--- a/mailpile/tests/test_mailutils.py
+++ b/mailpile/tests/test_mailutils.py
@@ -28,6 +28,15 @@ class TestCommands(MailPileUnittest):
         res = FormatMbxId("abcd")
         self.assertEqual(res, "abcd")
 
+    def test_FormatMbxId_string_len_more_than_four(self):
+        self.assertRaises(ValueError, lambda: FormatMbxId("abcde"))
+
+    def test_FormatMbxId_number(self):
+        res = FormatMbxId(123)
+        self.assertEqual(res, '003f')
+        res = FormatMbxId(12345)
+        self.assertEqual(res, '09ix')
+
     def test_FormatMbxId_unicode(self):
         res = FormatMbxId('Ţ¼')
-        self.assertEqual(res, "\xc5\xa2\xc2\xbc")        
+        self.assertEqual(res, "\xc5\xa2\xc2\xbc")


### PR DESCRIPTION
added tests
    test_decode_header_encoded_valid1
    test_decode_header_encoded_valid2
    test_FormatMbxId_string_len_less_than_four
    test_FormatMbxId_string_len_four
    test_FormatMbxId_unicode
