### PR TITLE
Fix non-spam button

### DIFF
--- a/shared-data/default-theme/html/jsapi/search/selection_actions.js
+++ b/shared-data/default-theme/html/jsapi/search/selection_actions.js
@@ -60,7 +60,7 @@ $(document).on('click', '.bulk-action-spam', function() {
       add: 'new',
       mid: Mailpile.UI.Selection.selected($context),
       context: $context.find('.search-context').data('context')
-    }, 'spam');
+    }, 'unspam');
   } else {
     Mailpile.UI.Tagging.tag_and_update_ui({
       del: ['new', 'trash'],

--- a/shared-data/default-theme/html/jsapi/search/selection_actions.js
+++ b/shared-data/default-theme/html/jsapi/search/selection_actions.js
@@ -53,12 +53,22 @@ $(document).on('click', '.bulk-action-trash', function(result) {
 /* Search - Bulk Action - Spam */
 $(document).on('click', '.bulk-action-spam', function() {
   var $context = Mailpile.UI.Selection.context(this);
-  Mailpile.UI.Tagging.tag_and_update_ui({
-    del: ['new', 'trash'],
-    add: 'spam',
-    mid: Mailpile.UI.Selection.selected($context),
-    context: $context.find('.search-context').data('context')
-  }, 'spam');
+  var action = $(this).data('action');
+  if (action === 'remove') {
+    Mailpile.UI.Tagging.tag_and_update_ui({
+      del: 'spam',
+      add: 'new',
+      mid: Mailpile.UI.Selection.selected($context),
+      context: $context.find('.search-context').data('context')
+    }, 'spam');
+  } else {
+    Mailpile.UI.Tagging.tag_and_update_ui({
+      del: ['new', 'trash'],
+      add: 'spam',
+      mid: Mailpile.UI.Selection.selected($context),
+      context: $context.find('.search-context').data('context')
+    }, 'spam');
+  }
 });
 
 

--- a/shared-data/default-theme/html/jsapi/ui/tagging.js
+++ b/shared-data/default-theme/html/jsapi/ui/tagging.js
@@ -17,6 +17,8 @@ var operations = {
               '{{_("Archived (num) messages")|escapejs}}'],
   'trash':   ['{{_("Moved 1 message to trash")|escapejs}}',
               '{{_("Moved (num)  messages to trash")|escapejs}}'],
+  'unspam':  ['{{_("Moved 1 message out of spam")|escapejs}}',
+              '{{_("Moved (num)  messages out of spam")|escapejs}}'],
   'spam':    ['{{_("Moved 1 message to spam")|escapejs}}',
               '{{_("Moved (num) messages to spam")|escapejs}}']
 };


### PR DESCRIPTION
If action is 'remove', remove the 'spam' tag and add the 'new' tag.