### PR TITLE
Fixes and updates the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
+MAINTAINER Aleksandar Todorović <aleksandar@r3bl.me>
 
 # Install dependencies
 RUN apt-get update -y && \
-    apt-get install -y openssl python-imaging python-jinja2 python-lxml libxml2-dev libxslt1-dev python-pgpdump spambayes
+    apt-get install -y tor python openssl python-imaging git python-jinja2 python-lxml libxml2-dev libxslt1-dev python-pgpdump spambayes python-pip && \
+    apt-get upgrade -y
 
 # Add code
-WORKDIR /Mailpile
-ADD . /Mailpile
+RUN git clone --recursive https://github.com/mailpile/Mailpile/ Mailpile
+WORKDIR "/Mailpile"
 
 # Create users and groups
 RUN groupadd -r mailpile \
@@ -20,16 +22,18 @@ RUN touch /mailpile-data/.gnupg/docker_placeholder
 RUN chown -R mailpile:mailpile /Mailpile
 RUN chown -R mailpile:mailpile /mailpile-data
 
-# Run as non-privileged user
-USER mailpile
+# Install pip requirements
+RUN pip install -r requirements.txt
 
 # Initialize mailpile
 RUN ./mp setup
 
 # Entrypoint
-CMD ./mp --www=0.0.0.0:33411 --wait
 EXPOSE 33411
 
 # Volumes
 VOLUME /mailpile-data/.local/share/Mailpile
 VOLUME /mailpile-data/.gnupg
+
+ENV MAILPILE_HOME=/mailpile-data/.local/share/Mailpile/
+CMD ["./mp", "--www=0.0.0.0:33411", "--wait"]


### PR DESCRIPTION
Since the current Dockerfile is not really building, I decided to edit it, make it working again and adjusting it so that it uses the newer version of Ubuntu (16.04).

**Worth noting:** This version of the Dockerfile follows the installation instructions for building Mailpile on Linux, so it uses Git to clone the code and then sets things up from there. Could be changed to `ADD` the code from the cloned repository, but in my opinion this is the easier solution since it allows people to just take the Dockerfile out of the repository and build it.
