### PR TITLE
Improve mail source tag creation and policies

### DIFF
--- a/mailpile/config/defaults.py
+++ b/mailpile/config/defaults.py
@@ -178,7 +178,7 @@ CONFIG_RULES = {
             'parent_tag':  (_('Parent tag for mailbox tags'), str, '!CREATE'),
             'guess_tags':  (_('Guess which local tags match'), bool, True),
             'create_tag':  (_('Create a tag for each mailbox?'), bool, True),
-            'visible_tags':(_('Make tags visible by default?'), bool, False),
+            'visible_tags':(_('Make tags visible by default?'), bool, True),
             'process_new': (_('Is a potential source of new mail'), bool, True),
             'apply_tags':  (_('Tags applied to messages'), str, []),
         }),

--- a/mailpile/mail_source/__init__.py
+++ b/mailpile/mail_source/__init__.py
@@ -555,11 +555,13 @@ class BaseMailSource(threading.Thread):
                 if len(name) < 4:
                     name = _('Mail: %s') % name
                 disco_cfg.parent_tag = name
+            from mailpile.plugins.tags import Slugify
             disco_cfg.parent_tag = self._create_tag(
                 disco_cfg.parent_tag,
                 use_existing=False,
                 label=False,
                 icon='icon-mailsource',
+                slug=Slugify(self.my_config.name, tags=self.session.config.tags),
                 visible=disco_cfg.visible_tags,
                 unique=False)
             if save:
@@ -610,7 +612,6 @@ class BaseMailSource(threading.Thread):
                     visible=(disco_cfg.visible_tags if (visible is None)
                              else visible),
                     label=as_label,
-                    slug='mailbox-%s' % mbx_cfg._key,
                     unique=False,
                     parent=parent)
             except (ValueError, IndexError):
@@ -671,9 +672,9 @@ class BaseMailSource(threading.Thread):
                 from mailpile.plugins.tags import Slugify
                 if self.my_config.name:
                     slug = Slugify('/'.join([self.my_config.name, tag_name]),
-                                   self.session.config.tags)
+                                   tags=self.session.config.tags)
                 else:
-                    slug = Slugify(tag_name, self.session.config.tags)
+                    slug = Slugify(tag_name, tags=self.session.config.tags)
             tag_id = self.session.config.tags.append({
                 'name': tag_name,
                 'slug': slug,

--- a/mailpile/plugins/contacts.py
+++ b/mailpile/plugins/contacts.py
@@ -1161,7 +1161,9 @@ class AddProfile(ProfileVCard(AddVCard)):
                     'label': False,
                     'display': 'invisible'
                 })
-                tags[vcard.tag].slug = 'account-%d' % len(tags)
+                from mailpile.plugins.tags import Slugify
+                tags[vcard.tag].slug = Slugify(
+                    'account-%s' % vcard.email, tags=self.session.config.tags)
 
         route_id = state.get('route_id')
         if route_id:

--- a/mailpile/plugins/contacts.py
+++ b/mailpile/plugins/contacts.py
@@ -971,7 +971,6 @@ def ProfileVCard(parent):
                     # so we save config to trigger instanciation.
                     self._background_save(config=True, wait=True)
                     src_obj = config.mail_sources[src_id]
-                    src_obj.set_tag_visibility(self._yn(prefix + 'visible-tags'))
 
                 else:
                     raise ValueError(_('Unhandled incoming mail protocol: %s'
@@ -1112,7 +1111,6 @@ class AddProfile(ProfileVCard(AddVCard)):
             'source-NEW-leave-on-server': True,
             'source-NEW-index-all-mail': True,
             'source-NEW-force-starttls': False,
-            'source-NEW-visible-tags': True,
             'source-NEW-copy-local': True,
             'source-NEW-delete-source': False,
             'security-best-effort-crypto': True,
@@ -1230,7 +1228,6 @@ class EditProfile(AddProfile):
             info[prefix + 'leave-on-server'] = (dp not in 'move')
             info[prefix + 'index-all-mail'] = (dp in ('move', 'sync', 'read')
                                                and disco.local_copy)
-            info[prefix + 'visible-tags'] = disco.visible_tags
             info[prefix + 'enabled'] = source.enabled
             if source.protocol == 'imap_tls':
                 info[prefix + 'protocol'] = 'imap'

--- a/mailpile/plugins/tags.py
+++ b/mailpile/plugins/tags.py
@@ -175,13 +175,13 @@ def GetTagID(cfg, tn):
 
 
 def Slugify(tag_name, tags=None):
-    slug = CleanText(tag_name.lower().replace(' ', '-'),
+    slug = CleanText(tag_name.lower().replace(' ', '-').replace('@', '-'),
                      banned=CleanText.NONDNS.replace('/', '')
                      ).clean.lower()
     n = 1
     while tags and slug in [t.slug for t in tags.values()]:
         n += 1
-        slug = Slugify('%s-%s' % (tag_name, n))
+        slug = Slugify('%s.%s' % (tag_name, n))
     return slug
 
 

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -460,7 +460,8 @@
 .icon-mime[type="application/x-tar"]:before,
 .icon-mime[type="application/x-winzip"]:before,
 .icon-mime[type="application/x-zip"]:before,
-.icon-mime[type="application/x-zip-compressed"]:before {
+.icon-mime[type="application/x-zip-compressed"]:before,
+.icon-mime[type="application/x-rar-compressed"]:before {
   content: "\e66b";
 }
 .icon-mime[type="audio/amr"]:before,
@@ -525,6 +526,7 @@
 .icon-mime[type="application/pdf"]:before,
 .icon-mime[type="application/x-download"]:before,
 .icon-mime[type="message/rfc822"]:before,
+.icon-mime[type="text/x-log"]:before,
 .icon-mime[type="text/scriptlet"]:before,
 .icon-mime[type="text/plain"]:before,
 .icon-mime[type="text/iuls"]:before,
@@ -7080,6 +7082,13 @@ div.notification-bubble span.action {
   position: absolute;
   display: inline-block;
   color: #cccccc;
+  top: 20%;
+}
+#sidebar a.sidebar-tag-settings {
+  position: absolute;
+  display: inline-block;
+  color: #cccccc;
+  right: 4px;
   top: 20%;
 }
 /* Sidebar - Subtags */

--- a/shared-data/default-theme/html/jsapi/ui/events.js
+++ b/shared-data/default-theme/html/jsapi/ui/events.js
@@ -15,12 +15,6 @@ $(document).on('click', '#button-sidebar-organize', function(e) {
 });
 
 
-$(document).on('click', '.sidebar-tag-archive', function(e) {
-  e.preventDefault();
-  Mailpile.UI.Sidebar.TagArchive();
-});
-
-
 $(document).on('click', '#button-sidebar-add', function(e) {
   e.preventDefault();
   Mailpile.UI.Modals.TagAdd({ location: 'sidebar' });

--- a/shared-data/default-theme/html/jsapi/ui/sidebar.js
+++ b/shared-data/default-theme/html/jsapi/ui/sidebar.js
@@ -2,7 +2,8 @@ Mailpile.UI.Sidebar.SubtagsRender = function(tid, gradual) {
   // FIXME: This assumes we have a Mailpile.config object that is up to date.
   //        That is not a safe or reasonable assumption...
 
-  if (_.indexOf(Mailpile.config.web.subtags_collapsed, tid) == -1) {
+  if ((_.indexOf(Mailpile.config.web.subtags_collapsed, tid) == -1)
+      && ($('#sidebar-tag-' + tid).not('.should-hide').length > 0)) {
     $('#sidebar-tag-' + tid).find('a.sidebar-tag-expand span').removeClass('icon-arrow-right').addClass('icon-arrow-down');
     if (gradual) {
       $('.subtag-of-' + tid).slideDown('fast');
@@ -11,7 +12,6 @@ Mailpile.UI.Sidebar.SubtagsRender = function(tid, gradual) {
       $('.subtag-of-' + tid).show();
     }
   } else {
-    //$('#sidebar-tag-' + tid).removeClass('show-subtags');
     $('#sidebar-tag-' + tid).find('a.sidebar-tag-expand span').removeClass('icon-arrow-down').addClass('icon-arrow-right');
     if (gradual) {
       $('.subtag-of-' + tid).slideUp('fast');
@@ -180,17 +180,27 @@ Mailpile.UI.Sidebar.OrganizeToggle = function(elem) {
 
     // Disable Drag & Drop
     $('a.sidebar-tag').draggable({ disabled: true });
+
+    // Display tags that are normally hidden
+    $('li.sidebar-tag.hide').addClass('should-hide').slideDown();
+    $('li.sidebar-tag.hide a.sidebar-tag').css({'opacity': 0.5});
     
     // Update Cursor Make Links Not Work
     $('.sidebar-sortable li').addClass('is-editing');
 
     // Hide Notification & Subtags
     $('a.sidebar-tag .notification').hide();
-    $('.sidebar-subtag').hide();
+    $('li.sidebar-tag .sidebar-tag-expand').hide();
+    $('.sidebar-subtag').slideUp();
 
-    // Add Minus Button
-    $.each($('.sidebar-tag'), function(key, value) {
-      $(this).append('<span class="sidebar-tag-archive icon-minus"></span>');
+    // Add Settings Button
+    $.each($('li.sidebar-tag'), function(key, value) {
+      var slug = $(this).data('slug');
+      $(this).append(
+        '<a class="sidebar-tag-settings auto-modal auto-modal-reload"' +
+        ' title="Edit: ' + slug + '"' +
+        ' href="/tags/edit.html?only='+slug+'">' +
+        '<span class="icon-settings"></span></a>');
     });
 
     // Update Edit Button
@@ -207,9 +217,13 @@ Mailpile.UI.Sidebar.OrganizeToggle = function(elem) {
     // Update Cursor Make Links Work
     $('.sidebar-sortable li').removeClass('is-editing');
 
-    // Show Notification / Hide Minus Button
+    // Show Notification / Remove Settings Button
     $('a.sidebar-tag .notification').show();
-    $('.sidebar-tag-archive').remove();
+    $('li.sidebar-tag .sidebar-tag-expand').show();
+    $('.sidebar-tag-settings').remove();
+
+    // Hide tags that are normally hidden
+    $('li.sidebar-tag.should-hide').slideUp();
 
     // Update Edit Button
     $elem.data('state', 'done');
@@ -218,18 +232,6 @@ Mailpile.UI.Sidebar.OrganizeToggle = function(elem) {
 
   $elem.data('message', old_message)
   $elem.find('span.text').html(new_message);
-};
-
-
-Mailpile.UI.Sidebar.TagArchive = function() {
-  // FIXME: This should use a modal or styled confirm dialogue and Int. language
-  alert('This will mark this tag as "archived" and remove it from your sidebar, you can go edit this in the Tags -> Tag Name -> Settings page at anytime');
-  var tid = $(this).parent().data('tid');
-  var setting = Mailpile.tag_setting(tid, 'display', 'archive');
-  Mailpile.API.settings_set_post(setting, function(result) { 
-    Mailpile.notification(result);
-    $('#sidebar-tag-' + tid).fadeOut();
-  });
 };
 
 

--- a/shared-data/default-theme/html/profiles/account-form.html
+++ b/shared-data/default-theme/html/profiles/account-form.html
@@ -514,14 +514,6 @@
               </span>
             </span>
 
-            <span class="source-settings-{{ new_rid }} imap imap_ssl">
-              <br>
-              <input type="checkbox" name="source-{{ new_rid }}-visible-tags" value="yes"
-                     {% if result['source-' + rid + '-visible-tags'] %}checked{% endif %}>
-              <span class="checkbox">
-                {{_("Create visible Mailpile tags for all folders")}}
-              </span>
-            </span>
             <div class='edit-provider-settings hide'><br>
               <a target=_blank class='edit-provider-settings button-secondary'>
                 <span class="icon-settings"></span> {{_("Enable IMAP")}}

--- a/shared-data/default-theme/html/profiles/index.html
+++ b/shared-data/default-theme/html/profiles/index.html
@@ -84,7 +84,7 @@
      {%- if 'x-mailpile-profile-tag' in p and p['x-mailpile-profile-tag'] in config.tags %}
        {%- set t = mailpile('tags', config.tags[p['x-mailpile-profile-tag']].slug).result.tags.0 %}
      {%- else %}
-       {%- set t = {'stats': {'new': '', 'all': ''}} %}
+       {%- set t = {'slug': 'all-mail', 'stats': {'new': '', 'all': ''}} %}
      {%- endif %}
      {%- if 'x-mailpile-profile-route' in p %}
       {%- set route = config.routes[p['x-mailpile-profile-route']] %}
@@ -105,17 +105,17 @@
                    <span class="icon icon-user" style="color: #070;"></span>
          </a>
        </td><td style='text-align: left;'>
-         <a href="{{ U('/in/inbox/?q=in:', config.tags[p['x-mailpile-profile-tag']].slug) }}">
+         <a href="{{ U('/in/inbox/?q=in:', t.slug) }}">
            {{ p.fn }}
          </a>
        </td><td style='text-align: left;'>{% for e in p.email %}
          {{ e.email }}{% if not loop.last %}<br>{% endif %}
        {%- endfor %}
-       </td><td><a href="{{ U('/in/', config.tags[p['x-mailpile-profile-tag']].slug, '/?q=is:unread') }}"><b>{{ t.stats.new }}</b></a>
-       </td><td><a href="{{ U('/in/', config.tags[p['x-mailpile-profile-tag']].slug, '/') }}">{{ t.stats.all }}</a>
+       </td><td><a href="{{ U('/in/', t.slug, '/?q=is:unread') }}"><b>{{ t.stats.new }}</b></a>
+       </td><td><a href="{{ U('/in/', t.slug, '/') }}">{{ t.stats.all }}</a>
        </td><td>
 {%- if is_dev_version() %}
-          <a href="{{ U('/in/outbox/?q=in:', config.tags[p['x-mailpile-profile-tag']].slug) }}">?</a>
+          <a href="{{ U('/in/outbox/?q=in:', t.slug) }}">?</a>
 {%- endif %}
        </td><td>
          {%- if not (p['x-mailpile-profile-source'] or []) %}

--- a/shared-data/default-theme/html/profiles/index.html
+++ b/shared-data/default-theme/html/profiles/index.html
@@ -105,17 +105,17 @@
                    <span class="icon icon-user" style="color: #070;"></span>
          </a>
        </td><td style='text-align: left;'>
-         <a href="{{ U('/in/inbox/?q=in:', p['x-mailpile-profile-tag']) }}">
+         <a href="{{ U('/in/inbox/?q=in:', config.tags[p['x-mailpile-profile-tag']].slug) }}">
            {{ p.fn }}
          </a>
        </td><td style='text-align: left;'>{% for e in p.email %}
          {{ e.email }}{% if not loop.last %}<br>{% endif %}
        {%- endfor %}
-       </td><td><a href="{{ U('/in/', p['x-mailpile-profile-tag'], '/?q=is:unread') }}"><b>{{ t.stats.new }}</b></a>
-       </td><td><a href="{{ U('/in/', p['x-mailpile-profile-tag'], '/') }}">{{ t.stats.all }}</a>
+       </td><td><a href="{{ U('/in/', config.tags[p['x-mailpile-profile-tag']].slug, '/?q=is:unread') }}"><b>{{ t.stats.new }}</b></a>
+       </td><td><a href="{{ U('/in/', config.tags[p['x-mailpile-profile-tag']].slug, '/') }}">{{ t.stats.all }}</a>
        </td><td>
 {%- if is_dev_version() %}
-          <a href="{{ U('/in/outbox/?q=in:', p['x-mailpile-profile-tag']) }}">?</a>
+          <a href="{{ U('/in/outbox/?q=in:', config.tags[p['x-mailpile-profile-tag']].slug) }}">?</a>
 {%- endif %}
        </td><td>
          {%- if not (p['x-mailpile-profile-source'] or []) %}

--- a/shared-data/default-theme/html/tags/form.html
+++ b/shared-data/default-theme/html/tags/form.html
@@ -259,7 +259,7 @@
 {%- else %}
     <button class="button-primary right" type="submit"><span class="icon-checked"></span> {{_("Save")}}</button>
 {%- endif %}
-{%- if state.command_url == "/tags/" and tag.type in ('tag', 'attribute') %}
+{%- if state.command_url == "/tags/" and tag.type in ('tag', 'attribute') and not tag.subtags %}
     <button class="button-warning" type="button" id="button-tag-delete"
             data-slug="{{tag.slug}}" data-dismiss="modal" aria-hidden="true">
       <span class="icon-minus"></span> {{_("Delete Tag")}}

--- a/shared-data/default-theme/html/tags/sidebar.html
+++ b/shared-data/default-theme/html/tags/sidebar.html
@@ -5,14 +5,14 @@
 {% macro render_sidebar_tag(tag) -%}
 {#  Show proper classes #}
 {%  if tag.type in ("drafts", "sent") %}
-<li id="sidebar-tag-{{tag.tid}}" data-tid="{{tag.tid}}" data-display_order="{{tag.display_order}}"
+<li id="sidebar-tag-{{tag.tid}}" data-slug="{{tag.slug}}" data-tid="{{tag.tid}}" data-display_order="{{tag.display_order}}"
     class="sidebar-tag sidebar-tags-default">
 {%  elif tag.type == "outbox" %}
-<li id="sidebar-tag-{{tag.tid}}" data-tid="{{tag.tid}}" data-display_order="{{tag.display_order}}"
+<li id="sidebar-tag-{{tag.tid}}" data-slug="{{tag.slug}}" data-tid="{{tag.tid}}" data-display_order="{{tag.display_order}}"
     class="sidebar-tag sidebar-tags-default {% if tag.stats.all == 0 %} hide{% endif %}">
 {%  else %}
-<li id="sidebar-tag-{{tag.tid}}" data-tid="{{tag.tid}}" data-display_order="{{tag.display_order}}"
-    class="sidebar-tag sidebar-tags-draggable">
+<li id="sidebar-tag-{{tag.tid}}" data-slug="{{tag.slug}}" data-tid="{{tag.tid}}" data-display_order="{{tag.display_order}}"
+    class="sidebar-tag sidebar-tags-draggable{% if tag.display == "archive" %} hide should-hide{% endif %}">
 {%  endif %}
 
 {%- if tag.slug == "outbox" or tag.slug == "drafts" %}
@@ -48,11 +48,11 @@
 
 </li>
 {%  if tag.subtags %}
-{%   for subtag in tag.subtags if subtag.display == 'tag' %}
+{%   for subtag in tag.subtags if subtag.display in ('tag', 'archive') %}
 <li id="sidebar-tag-{{subtag.tid}}"
     data-tid="{{subtag.tid}}" data-display_order="{{subtag.display_order}}"
     class="sidebar-subtag sidebar-tags-draggable subtag-of-{{tag.tid}}
-           {%- if subtags_collapsed %} hide{% endif %}">
+           {%- if subtags_collapsed or 'archive' in (subtag.display, tag.display) %} hide should-hide{% endif %}">
   <a href="{{subtag.url}}" class="sidebar-tag {% if subtag.stats.new %}has-unread{% endif %} {{ navigation_on(result.search_tag_ids, subtag.tid) }}" title="{{subtag.name}} {{subtag.stats.all}}" data-tid="{{subtag.tid}}">
     <span class="icon {{subtag.icon}}" style="color: {{theme_settings().colors[subtag.label_color]}};"></span>
     <span class="name">{{subtag.name}}</span>
@@ -76,7 +76,7 @@
   <hr>
   <ul id="sidebar-tag" class="sidebar-sortable">
     {%- for tag in result.tags -%}
-      {%- if tag.display == 'tag' -%}
+      {%- if tag.display in ('tag', 'archive') -%}
         {{ render_sidebar_tag(tag) }}
       {%- endif -%}
     {%- endfor -%}

--- a/shared-data/default-theme/less/app/sidebar.less
+++ b/shared-data/default-theme/less/app/sidebar.less
@@ -159,6 +159,14 @@
    top: 20%;
  }
 
+ #sidebar a.sidebar-tag-settings {
+   position: absolute;
+   display: inline-block;
+   color: @grayMid;
+   right: 4px;
+   top: 20%;
+ }
+
 
 /* Sidebar - Subtags */
 


### PR DESCRIPTION
This PR improves and simplifies how Mailpile mail sources create tags.

1. The slugs/links now have meaning (instead of just being unique IDs)
2. Fix the "Organize" sidebar mode to give direct access to tag settings and show archived tags
3. Simplify tag creation policy: always add to sidebar, never create labels

Individual commit messages have more details.

The sidebar org mode change picks up a few minor changes to the default less-compiled CSS as a side-effect.