### PR TITLE
fixed #1561 Got It button has wrong cursor

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -3348,6 +3348,10 @@ input[type="button"].button-small {
   user-select: none;
   transition-duration: 0.2s;
 }
+/* OK, Got it */
+.ok-got-it {
+  cursor: pointer;
+}
 /* Primary */
 button.button-primary,
 input[type="submit"].button-primary,


### PR DESCRIPTION
The "Got it" button had a text select cursor, as described in the issue. Only the checkmark icon had a pointer, now the clickable text has the correct cursor as well.