### PR TITLE
fixed #1627 - added tooltip to compose button on profile page

### DIFF
--- a/shared-data/default-theme/html/profiles/index.html
+++ b/shared-data/default-theme/html/profiles/index.html
@@ -94,7 +94,7 @@
     <tr valign="top" class="message">
        <td width='1%'>
          {%- if route %}
-         <a data-from="{{ p.email.0.email }}" class="button-compose" href="#">
+         <a data-from="{{ p.email.0.email }}" class="button-compose" title="Compose as {{ p.email.0.email }}" href="#">
            <span class="icon icon-compose"></span>
          </a>
          {%- endif %}


### PR DESCRIPTION
As said, fixed #1627 

I added a tooltip, namely "Compose as example@example.com" where obviously the selected address replaces the example.

I chose the approach with the address since people tend to have the same name on different accounts and it is the address that counts.