### PR TITLE
Correct default ssl_version argument. Fix #1591.

### DIFF
--- a/mailpile/conn_brokers.py
+++ b/mailpile/conn_brokers.py
@@ -538,7 +538,7 @@ class BaseConnectionBrokerProxy(TcpConnectionBroker):
     SUPPORTS = []
     WANTS = [Capability.OUTGOING_RAW]
     REJECTS = None
-    SSL_VERSION = None
+    SSL_VERSION = ssl.PROTOCOL_SSLv23
 
     def _proxy_address(self, address):
         return address


### PR DESCRIPTION
The default ssl_version argument to ssl.wrap_socket is a constant, not
`None`. This was causing a TypeError.
