### PR TITLE
Prevent unwanted selection in search field

### DIFF
--- a/shared-data/default-theme/html/jsapi/ui/topbar.js
+++ b/shared-data/default-theme/html/jsapi/ui/topbar.js
@@ -1,5 +1,5 @@
 /* Topbar - Search - Focus */
-$(document).on('click', '#search-query', function() {
+$(document).on('focus', '#search-query', function() {
   $(this).select();
 });
 


### PR DESCRIPTION
The whole search query is selected only if the search field didn't have
focus before the click event. This allows the user to select substrings
and cursor positions using the mouse.