### PR TITLE
Sanitize avatars to protect against XSS attacks.

### DIFF
--- a/mailpile/vcard.py
+++ b/mailpile/vcard.py
@@ -2,6 +2,8 @@ import random
 import threading
 import time
 
+from markupsafe import escape
+
 import mailpile.util
 from mailpile.i18n import gettext as _
 from mailpile.i18n import ngettext as _n
@@ -1163,7 +1165,7 @@ class AddressInfo(dict):
 
         photos = vcard.get_all('photo')
         if photos:
-            self['photo'] = photos[0].value
+            self['photo'] = escape(photos[0].value)
 
         crypto_policy = vcard.crypto_policy
         if crypto_policy:


### PR DESCRIPTION
Avatars are sourced from third parties we have no particular reason to
trust.

This is a followup to discussion in #1669.