### PR TITLE
[WIP] Switch to less-elements-old

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "plupload": "~2.1.2",
     "purl": "~2.3.1",
     "qtip2": "~2.1.1",
-    "rebar": "~0.3.0",
+    "rebar": "~0.3.2",
     "select2": "3.4.7",
     "typeahead.js": "~0.10.5",
     "jqueryui-touch-punch": "*",

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "jquery-slugify": "~1.0.3",
     "jquery-timer": "*",
     "jquery.ui": "~1.10.4",
-    "less-elements": "master",
+    "less-elements-old": "~1.0",
     "listjs": "~1.1.0",
     "mousetrap": "~1.4.6",
     "moxie": "~1.3.4",

--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -70,7 +70,7 @@ override_dh_auto_build:
 	ln -s /usr/share/javascript/animate.css/animate.css bower_components/animate.css/animate.css
 
 	mkdir -p bower_components/less-elements
-	ln -s /usr/share/javascript/less-elements/elements.less bower_components/less-elements/elements.less
+	ln -s /usr/share/javascript/less-elements/elements.less bower_components/less-elements-old/elements.less
 
 	mkdir -p bower_components/rebar
 	ln -s /usr/share/javascript/rebar/less bower_components/rebar/less

--- a/scripts/less-compiler.in
+++ b/scripts/less-compiler.in
@@ -6,7 +6,6 @@ all: shared-data/default-theme/css/default.css \
 
 shared-data/default-theme/css/default.css: .less-deps
 	@(cd shared-data/default-theme/less && \
-            #lessc --02 -x default.less \
             lessc default.less \
               |perl -npe 's,(libraries|app)/,,g' \
               |perl -npe 's,/shared-data/,../,g' \

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -3349,7 +3349,11 @@ input[type="button"].button-small {
   transition-duration: 0.2s;
 }
 /* Primary */
+button,
 button.button-primary,
+input[type="submit"],
+input[type="reset"],
+input[type="button"],
 input[type="submit"].button-primary,
 input[type="reset"].button-primary,
 input[type="button"].button-primary,
@@ -3427,7 +3431,7 @@ input[type="reset"].button-info:hover,
 input[type="button"].button-info:hover,
 a.button-info:hover {
   border-color: #b3b3b3;
-  background-color: #e9e9e9;
+  background-color: #dcdcdc;
 }
 button.button-info:active,
 input[type="submit"].button-info:active,
@@ -3435,7 +3439,7 @@ input[type="reset"].button-info:active,
 input[type="button"].button-info:active,
 a.button-info:active {
   border-color: #9a9a9a;
-  background-color: #e9e9e9;
+  background-color: #dcdcdc;
   box-shadow: inset 0 0.17em 0.1em rgba(0, 0, 0, 0.3);
 }
 /* Alert */
@@ -3612,8 +3616,14 @@ input::-moz-focus-inner {
 .right {
   float: right;
 }
-.vertical {
+.top {
+  vertical-align: top !important;
+}
+.middle {
   vertical-align: middle !important;
+}
+.bottom {
+  vertical-align: bottom !important;
 }
 .text-left {
   text-align: left !important;
@@ -3623,6 +3633,12 @@ input::-moz-focus-inner {
 }
 .text-right {
   text-align: right !important;
+}
+.text-top {
+  vertical-align: text-top !important;
+}
+.text-bottom {
+  vertical-align: text-bottom !important;
 }
 /* Display */
 .hide {
@@ -4385,32 +4401,32 @@ h6 a {
 h1 {
   font-size: 36px;
   line-height: 36px;
-  margin-bottom: 30px;
+  margin-bottom: 0px;
 }
 h2 {
   font-size: 30px;
   line-height: 30px;
-  margin-bottom: 30px;
+  margin-bottom: 0px;
 }
 h3 {
   font-size: 24px;
   line-height: 24px;
-  margin-bottom: 30px;
+  margin-bottom: 0px;
 }
 h4 {
   font-size: 21px;
   line-height: 21px;
-  margin-bottom: 30px;
+  margin-bottom: 0px;
 }
 h5 {
   font-size: 18px;
   line-height: 18px;
-  margin-bottom: 30px;
+  margin-bottom: 0px;
 }
 h6 {
   font-size: 14px;
   line-height: 14px;
-  margin-bottom: 30px;
+  margin-bottom: 0px;
 }
 .subheader {
   color: #777;
@@ -4468,22 +4484,51 @@ blockquote cite a:visited {
   color: #555;
 }
 /* Pre & Code */
-code,
+pre {
+  word-wrap: normal;
+  display: block;
+  padding: 4px 8px;
+}
 pre,
 .pre {
   margin-bottom: 20px;
-  background: #f6f6f6;
+  background: #e9e9e9;
   color: #333333;
-  padding: 4px 8px;
   border: 1px solid #b3b3b3;
   border-radius: 3px;
-  font-family: 'Courier';
+  font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 14px;
-  font-weight: bold;
+  font-weight: normal;
 }
-code,
-pre {
-  display: inline-block;
+code {
+  display: inline;
+  border: 1px solid #b3b3b3;
+  border-radius: 3px;
+  background: #e9e9e9;
+  padding: 2px 5px;
+  font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 70%;
+  font-weight: normal;
+}
+pre code {
+  border: 0px;
+  font-size: 100%;
+}
+/* Special Classes */
+.text-detail {
+  color: #b3b3b3;
+}
+a.link-detail,
+a.link-detail:visited {
+  color: #b3b3b3;
+  font-weight: normal !important;
+}
+a.link-detail:hover {
+  color: #4d4d4d;
+}
+a.disabled {
+  pointer-events: none;
+  cursor: default;
 }
 /* Validation */
 .validation-message {
@@ -5252,7 +5297,7 @@ html[dir="rtl"] .select2-search-choice-close {
 .dropdown-menu > .disabled > a,
 .dropdown-menu > .disabled > a:hover,
 .dropdown-menu > .disabled > a:focus {
-  color: #f6f6f6;
+  color: #e9e9e9;
 }
 .dropdown-menu > .disabled > a:hover,
 .dropdown-menu > .disabled > a:focus {
@@ -5281,7 +5326,7 @@ html[dir="rtl"] .select2-search-choice-close {
   padding: 3px 20px;
   font-size: 12px;
   line-height: 20px;
-  color: #f6f6f6;
+  color: #e9e9e9;
   white-space: nowrap;
 }
 .dropdown-backdrop {
@@ -5670,7 +5715,7 @@ div.setup-box {
   margin: 0px auto;
   padding: 25px;
   border-radius: 5px;
-  background: #f6f6f6;
+  background: #e9e9e9;
   border: 1px solid #cccccc;
 }
 div.setup-box-small {
@@ -5709,7 +5754,7 @@ a.setup-progress-circle {
 a.setup-progress-circle:hover,
 a.setup-progress-circle:hover span.icon {
   color: #4d4d4d;
-  background: #dddddd;
+  background: #d0d0d0;
 }
 a.setup-progress-circle span.icon {
   display: inline-block;
@@ -5717,11 +5762,11 @@ a.setup-progress-circle span.icon {
 }
 a.setup-progress-circle.on {
   background: #337fb2;
-  border: 1px solid #f6f6f6;
+  border: 1px solid #e9e9e9;
 }
 a.setup-progress-circle.complete {
   background: #4b9441;
-  border: 1px solid #f6f6f6;
+  border: 1px solid #e9e9e9;
 }
 a.setup-progress-circle.on span.icon,
 a.setup-progress-circle.complete span.icon {
@@ -6054,7 +6099,7 @@ div.motd a.motd-signed {
   left: 50%;
   margin-top: 0px;
   margin-left: -200px;
-  background: #f6f6f6;
+  background: #e9e9e9;
   border-radius: 6px;
   z-index: 2001;
 }
@@ -6081,7 +6126,7 @@ div.motd a.motd-signed {
 #login-left {
   width: 65%;
   height: 100px;
-  background: #f6f6f6;
+  background: #e9e9e9;
   border-right: 4px solid #cccccc;
   box-sizing: border-box;
   display: inline-block;
@@ -6090,7 +6135,7 @@ div.motd a.motd-signed {
 #login-right {
   width: 35%;
   height: 100%;
-  background: #f6f6f6;
+  background: #e9e9e9;
   border-left: 2px solid #cccccc;
   box-sizing: border-box;
   display: inline-block;
@@ -6275,7 +6320,7 @@ div.motd a.motd-signed {
   width: 100%;
   min-height: 45px;
   display: block;
-  background: #f6f6f6;
+  background: #e9e9e9;
   border-bottom: 1px solid #b3b3b3;
   box-sizing: border-box;
 }
@@ -6383,7 +6428,7 @@ div.motd a.motd-signed {
   left: 0;
   overflow-y: scroll;
   z-index: 5;
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 #content-tall-view {
   top: 0px;
@@ -6504,7 +6549,7 @@ label.radio-list-item div {
   vertical-align: middle;
 }
 span.radio-list-item-detail {
-  color: #f6f6f6;
+  color: #e9e9e9;
 }
 /* List Items */
 /* REBAR: Move these more global styles to Rebar */
@@ -6547,7 +6592,7 @@ ul.items li.grouped h5 {
   border-radius: 3px;
 }
 .rectangles-outer:hover {
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 /* User Card - Avatar, Name, Address */
 .global-user-avatar {
@@ -6702,7 +6747,7 @@ div.notification-bubble span.action {
   color: #b3b3b3;
 }
 #notifications a:hover {
-  color: #f6f6f6;
+  color: #e9e9e9;
 }
 #notifications a.notifications-close-all,
 #notifications a.notification-close {
@@ -6724,7 +6769,7 @@ div.notification-bubble span.action {
 }
 /* Selects */
 .checkbox-item-picker {
-  background: #f6f6f6;
+  background: #e9e9e9;
   margin: 0px 20px 20px 0px;
   padding: 5px;
   display: inline-block;
@@ -6753,7 +6798,7 @@ div.notification-bubble span.action {
   min-width: 800px;
   border-bottom: 1px solid #b3b3b3;
   box-sizing: border-box;
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 .topbar-logo {
   width: 67px;
@@ -6911,7 +6956,7 @@ div.notification-bubble span.action {
 /* Sidebar */
 #sidebar {
   position: fixed;
-  background: #f6f6f6;
+  background: #e9e9e9;
   top: 62px;
   bottom: 0px;
   width: 225px;
@@ -6950,7 +6995,7 @@ div.notification-bubble span.action {
   bottom: 0px;
   padding-top: 10px;
   padding-bottom: 10px;
-  background: #f6f6f6;
+  background: #e9e9e9;
   border-top: 1px solid #b3b3b3;
 }
 #sidebar-bottom a {
@@ -7239,14 +7284,14 @@ a.sidebar-tag span.sidebar-tag-archive:hover {
   padding: 7.5px 0;
   box-sizing: content-box;
   border-top: 1px solid #b3b3b3;
-  background: #f6f6f6;
+  background: #e9e9e9;
   font-size: 12px;
   font-weight: bold;
   line-height: 12px;
   color: #4d4d4d;
 }
 .attachment:hover {
-  background: #f6f6f6;
+  background: #e9e9e9;
   border: 1px solid #b3b3b3;
 }
 .attachment:hover div.filename {
@@ -7256,11 +7301,9 @@ a.sidebar-tag span.sidebar-tag-archive:hover {
 .attachment:hover span.extension {
   color: #4d4d4d;
 }
-
 .attachment-progress-bar {
   padding-left: 10px;
 }
-
 /* Crypto */
 .compose-crypto-signature.none {
   color: #b3b3b3;
@@ -7293,7 +7336,7 @@ a.sidebar-tag span.sidebar-tag-archive:hover {
 /* Compose */
 .form-compose {
   padding: 15px 20px 10px 20px;
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 .form-compose label {
   display: block;
@@ -7842,7 +7885,7 @@ label.compose-attach-key span.icon-key {
   text-transform: capitalize;
 }
 .modal-body-light-gray {
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 /* Modal - Tag picker */
 table.modal-tag-picker-items {
@@ -7895,7 +7938,7 @@ tr.modal-tag-picker-item td.checkbox {
   margin-bottom: 20px;
 }
 .searchkey-result-item:hover {
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 .searchkey-result-item .avatar {
   display: inline-block;
@@ -7993,7 +8036,7 @@ tr.modal-tag-picker-item td.checkbox {
 }
 #search-params a {
   padding: 5px 10px;
-  background: #f6f6f6;
+  background: #e9e9e9;
   color: #4d4d4d;
   font-family: "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -8001,7 +8044,7 @@ tr.modal-tag-picker-item td.checkbox {
   border: 1px solid #b3b3b3;
 }
 #search-params a:hover {
-  background-color: #d0d0d0;
+  background-color: #c3c3c3;
 }
 /* Pile */
 #pile-results {
@@ -8014,10 +8057,10 @@ tr.modal-tag-picker-item td.checkbox {
   background: #ffffff;
 }
 #pile-results tr.result:hover {
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 #pile-results tr.result-hover {
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 #pile-results tr.result-on {
   background: #faf7d0;
@@ -8242,11 +8285,11 @@ tr.modal-tag-picker-item td.checkbox {
 #pile-results tr.full-message {
   border-top: 6px solid;
   border-bottom: 6px solid;
-  border-color: #f6f6f6;
+  border-color: #e9e9e9;
 }
 #pile-results tr.full-message td.draggable {
-  border-color: #f6f6f6;
-  background: #f6f6f6;
+  border-color: #e9e9e9;
+  background: #e9e9e9;
 }
 #pile-results tr.result-on.full-message,
 #pile-results tr.result-on.full-message td.draggable {
@@ -8313,7 +8356,7 @@ tr.modal-tag-picker-item td.checkbox {
   padding: 2px 10px;
 }
 #pile-results .thread-container .thread-message:hover {
-  background: #f6f6f6;
+  background: #e9e9e9;
   border-radius: 3px;
 }
 #pile-results .message-details .header-raw.hide,
@@ -8519,7 +8562,7 @@ tr.modal-tag-picker-item td.checkbox {
   margin: 10px 0 0 -10px;
   padding-top: 1px;
   border-top: 2px dotted;
-  border-top-color: #f6f6f6;
+  border-top-color: #e9e9e9;
 }
 #pile-results .message-inline-crypto-info {
   display: inline-block;
@@ -9041,7 +9084,7 @@ iframe.message-part-html {
   margin: 30px auto;
   padding: 10px;
   color: #4d4d4d;
-  background: #f6f6f6;
+  background: #e9e9e9;
   opacity: 0.65;
   white-space: normal;
   transition: opacity 1s;
@@ -9146,7 +9189,7 @@ a.message-actions-quote {
   line-height: 14px;
 }
 a.message-actions-quote:hover {
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 /* Tags */
 .tag-card-name {
@@ -9215,7 +9258,7 @@ a.modal-tag-color-option:hover {
   text-align: center;
 }
 .item-file:hover {
-  background: #f6f6f6;
+  background: #e9e9e9;
 }
 .item-file-icon {
   display: block;

--- a/shared-data/default-theme/less/config.less
+++ b/shared-data/default-theme/less/config.less
@@ -14,7 +14,7 @@
 	@white: #FFFFFF;
 	@black: #333333;
 
-	@grayLight: #F6F6F6;
+	@grayLight: #E9E9E9;
 	@grayMid: #CCCCCC;
 	@gray: #B3B3B3;
 	@grayDark: #4D4D4D;
@@ -93,10 +93,14 @@
   @pre-padding: 4px 8px;
   @pre-border: 1px solid @gray;
   @pre-border-radius: 3px;
-  @pre-font-family: 'Courier';
+  @pre-font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   @pre-font-size: 14px;
-  @pre-font-weight: bold;
+  @pre-font-weight: normal;
 
+  @code-font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  @code-font-size: 14px;
+  @code-font-weight: normal;
+  @code-padding: 2px 5px;
 
 /* Links */
 

--- a/shared-data/default-theme/less/config.less
+++ b/shared-data/default-theme/less/config.less
@@ -1,7 +1,7 @@
 /* Mailpile v0.1.0
  * config.less
  */
-  
+
 /* Mailpile */
 
   @mailpile-text-font-family: Mailpile-300, "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -37,7 +37,7 @@
 
   @colorSelect: lighten(@yellow, 35%);
   @colorSelectHover: lighten(@yellow, 30%);
-  @colorNew: lighten(@blueLight, 23%); 
+  @colorNew: lighten(@blueLight, 23%);
   @colorExpand: lighten(@blueLight, 18%);
 
 
@@ -50,7 +50,7 @@
 
 
 /* Container */
-	
+
 	@container-desktop-max-width: 100%;
 	@container-desktop-width: 1025px;
 	@container-tablet-width: 768px;
@@ -112,7 +112,7 @@
 
 	@headings-color: #333333;
 	@headings-font-family: @mailpile-text-font-family-bold;
-	@headings-font-weight: normal;	
+	@headings-font-weight: normal;
 	@headings-letter-spacing: 0px;
 	@headings-size-h1: 36px;
 	@headings-size-h2: 30px;
@@ -132,7 +132,7 @@
 	@navigation-text-dark: #818181;
 	@navigation-elements: #AAAAAA;
 	@navigation-shadows: #EEEEEE;
-	
+
 	@navigation-sub-background: #d9d9d9;
 	@navigation-sub-text: #EEEEEE;
 	@navigation-sub-text-hover: #AAAAAA;
@@ -154,7 +154,7 @@
 	@list-ordered-type: none outside;
 
   @list-item-horizontal-margin: 0px;
-  
+
 
 /* Separators */
 
@@ -162,7 +162,7 @@
 	@blockquote-font-style: italic;
 	@blockquote-line-height: 24px;
 	@blockquote-color: #666666;
-	
+
 	@hr-border-type: solid;
 	@hr-border-color: @gray;
 	@hr-border-width: 1px;
@@ -205,7 +205,7 @@
     background: @background;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 0px 0px rgba(0, 0, 0, 0.2);
   }
-  
+
   .button-colors-hover(@border-color, @background) {
     border-color: @border-color;
     background-color: @background;
@@ -364,7 +364,7 @@
 	@grid-gutter: 1%;
 	@grid-column-count: 16;
 
-	@grid-tablet-width: 100%;	
+	@grid-tablet-width: 100%;
 	@grid-mobile-width: 100%;
 
 
@@ -392,7 +392,7 @@
 
   @caret-width-base:          4px;
   @caret-width-large:         5px;
-  
+
   @zindex-navbar:            1000;
   @zindex-dropdown:          1000;
   @zindex-popover:           1010;
@@ -410,7 +410,7 @@
   @line-height-base: @base-line-height;
   @line-height-computed: @base-line-height;
 
-  @screen-sm:                 768px;  
+  @screen-sm:                 768px;
   @screen-sm-min:             @screen-sm;
   @screen-md-min:             1024px;
 
@@ -423,14 +423,14 @@
   @dropdown-bg:                    @white;
   @dropdown-border:                rgba(0,0,0,.15);
   @dropdown-fallback-border:       @grayMid;
-  @dropdown-divider-bg:            @grayMid;  
+  @dropdown-divider-bg:            @grayMid;
   @dropdown-link-color:            @grayDark;
   @dropdown-link-hover-color:      @white;
   @dropdown-link-hover-bg:         @grayDark;
   @dropdown-link-active-color:     @red;
   @dropdown-link-active-bg:        @grayDark;
   @dropdown-link-disabled-color:   @grayLight;
-  @dropdown-header-color:          @grayLight;  
+  @dropdown-header-color:          @grayLight;
   @dropdown-caret-color:           @grayDark;
 
 
@@ -439,18 +439,18 @@
   @zindex-modal:                  1050;
   @zindex-modal-background:       1040;
 
-  @modal-inner-padding:           20px;  
+  @modal-inner-padding:           20px;
   @modal-title-padding:           15px;
-  @modal-title-line-height:       1.428571429;  
+  @modal-title-line-height:       1.428571429;
   @modal-content-bg:              @white;
   @modal-content-border-color:    @grayMid;
   @modal-content-fallback-border-color: @white;
-  
+
   @modal-backdrop-bg:             @black;
   @modal-backdrop-opacity:        .5;
   @modal-header-border-color:     @grayMid;
   @modal-footer-border-color:     @modal-header-border-color;
-  
+
   @modal-lg:                      900px;
   @modal-md:                      600px;
   @modal-sm:                      300px;

--- a/shared-data/default-theme/less/default.less
+++ b/shared-data/default-theme/less/default.less
@@ -12,7 +12,7 @@
 
 /* Bower */
 @import (less) "../../../bower_components/animate.css/animate.css";
-@import "../../../bower_components/less-elements/elements.less";
+@import "../../../bower_components/less-elements-old/elements.less";
 
 /* Rebar - these files reset and style all the basic HTML elements */
 @import "../../../bower_components/rebar/less/rebar/base.less";


### PR DESCRIPTION
less-elements vanished from github ; and the [official site](http://lesselements.com/) does not even
mention a license. So, there is this *less-elements-old* fork remaining ; it's
not under active development (codebase is tiny) but at least it's online and
FLOSS :-)

Current PR is not sufficient, I am [waiting for a release of Rebar](https://github.com/bnvk/Rebar/pull/24#issuecomment-261797756) including the same patch, which also depends on less-elements old.

MP will need to depend on that new rebar.
