### PR TITLE
Launch browser at start-up option

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -80,7 +80,8 @@ def Interact(session):
 
     try:
         prompt = session.ui.term.color('mailpile> ',
-                                       color=session.ui.term.BLACK,
+                                       color=session.ui.term.BLUE,
+                                # blue is better for dark environments
                                        weight=session.ui.term.BOLD,
                                        readline=True)
         while not mailpile.util.QUITTING:
@@ -144,9 +145,13 @@ class InteractCommand(Command):
         # Note: We do *not* update the MOTD on startup, to keep things
         #       fast, and to avoid leaking our IP on setup, before Tor
         #       has been configured.
-        splash = HelpSplash(session, 'help', []).run()
         motd = MessageOfTheDay(session, 'motd', ['--noupdate']).run()
-        session.ui.display_result(splash)
+        launch_browser = raw_input('Launch browser? [y/n] ').decode('utf-8').strip()
+        if launch_browser == 'y':
+            splash = HelpSplash(session, 'help', []).run()
+            session.ui.display_result(splash)
+        else:
+            splash = HelpSplash(session, 'help', [])
         print  # FIXME: This is a hack!
         session.ui.display_result(motd)
 


### PR DESCRIPTION
This is so that a browser won't start up instantly for command line users and having to close the browser before using the command line