### PR TITLE
Change of thread tree symbols to work under Windows and Mac OSX

### DIFF
--- a/mailpile/plugins/search.py
+++ b/mailpile/plugins/search.py
@@ -214,8 +214,8 @@ class SearchResults(dict):
 
     _BAR = u'\u2502'
     _FORK = u'\u251c'
-    _FIRST = u'\u256d'
-    _LAST = u'\u2570'
+    _FIRST = u'\u250c'
+    _LAST = u'\u2514'
     _BLANK = u' '
     _DASH = u'\u2500'
     _TEE = u'\u252c'

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -7,15 +7,15 @@
 ================================================== */
 /* @license
  * Mailpile font designed for Mailpile
- * 
+ *
  * You may obtain a copy of the license at the URLs below.
- * 
+ *
  * Webfont: Mailpile by Brennan Novak
  * URL: http://github.com/mailpile/fonts
- * 
+ *
  * Mailpile font is licensed under the SIL Open Font License (OFL)
  * http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL
- * 
+ *
  * © 2013 Mailpile
 */
 @font-face {
@@ -8340,7 +8340,7 @@ tr.modal-tag-picker-item td.checkbox {
   border: 0;
   position: relative;
   top: 4px;
-  font-size: 34px;
+  font-size: 40px;
   font-family: monospace;
   line-height: 34px;
   color: #b3b3b3;

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -263,7 +263,7 @@
   #pile-results .thread-message .thread-tree {
     margin: 0; padding: 0; border: 0;
     position: relative; top: 4px;
-    font-size: 34px; font-family: monospace;
+    font-size: 40px; font-family: monospace;
     line-height: 34px;
     color: @gray;
     white-space: pre;
@@ -484,7 +484,7 @@
     margin: 0;
     padding: 0;
     //width: 111%;
-    //transform: scale(0.9); 
+    //transform: scale(0.9);
     //transform-origin: 0 0;
   }
 


### PR DESCRIPTION
The thread tree or conversation view uses multiple unicode symbols to represent the tree. Unfortunately they don't work on all OS's. The following symbols are available:

U+250C (corner up)
┌
U+250D (corner up small)
┍
U+2514 (corner down)
└
U+2515 (corner down small)
┕
U+256D (round up)
╭
U+2570 (round down)
╰

As it turns out in Windows 7 the standard monospace font family "Courier New" contains only the following symbols (of the six mentioned above):
U+250C / U+2514
The remaining four symbols get replaced with the corresponding symbol of the "MS Mincho" font family (which uses a different width). Mac OSX seems to have a similar issue. Therefore I replaced the round corners with their angled counterpart.

This fixes #1671.