### PR TITLE
Be more careful not to leak passwords into event log

### DIFF
--- a/mailpile/commands.py
+++ b/mailpile/commands.py
@@ -475,7 +475,9 @@ class Command(object):
                           'message': self.message or ''}
 
     def _sloppy_copy(self, data, name=None):
-        if name and 'pass' == name[:4]:
+        if name and (name[:4] in ('pass', 'csrf') or
+                     'password' in name or
+                     'passphrase' in name):
             data = '(SUPPRESSED)'
         def copy_value(v):
             try:


### PR DESCRIPTION
During setup, passwords from the auto-config flow could end up in clear-text in the event log (which is not yet encrypted because the user hasn't approved the default privacy settings). Passwords would also end up in the clear in the log if the user disabled encryption.

This should fixes both cases.