### PR TITLE
Fixed hack in app.py

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -147,7 +147,6 @@ class InteractCommand(Command):
         splash = HelpSplash(session, 'help', []).run()
         motd = MessageOfTheDay(session, 'motd', ['--noupdate']).run()
         session.ui.display_result(splash)
-        print  # FIXME: This is a hack!
         session.ui.display_result(motd)
 
         Interact(session)

--- a/mailpile/plugins/motd.py
+++ b/mailpile/plugins/motd.py
@@ -88,7 +88,7 @@ class MessageOfTheDay(Command):
                 return ''
 
             date = dtime.fromtimestamp(self.result.get('timestamp', 0))
-            return '%s, %4.4d-%2.2d-%2.2d:\n\n    %s\n\n*** %s ***\n' % (
+            return '\n%s, %4.4d-%2.2d-%2.2d:\n\n    %s\n\n*** %s ***\n' % (
                 _('Message Of The Day'),
                 date.year, date.month, date.day,
                 motd.replace('\n', '\n    '),


### PR DESCRIPTION
There is no need for the print command between the MoTD and the splash message.