### PR TITLE
1st draft at sensible behaviour when out of disk space. Fixes #1696

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -12,7 +12,8 @@ from mailpile.conn_brokers import DisableUnbrokeredConnections
 from mailpile.i18n import gettext as _
 from mailpile.i18n import ngettext as _n
 from mailpile.plugins import PluginManager
-from mailpile.plugins.core import Help, HelpSplash, Load, Rescan, Quit
+from mailpile.plugins.core import Help, HelpSplash, HealthCheck
+from mailpile.plugins.core import Load, Rescan, Quit
 from mailpile.plugins.motd import MessageOfTheDay
 from mailpile.ui import ANSIColors, Session, UserInteraction, Completer
 from mailpile.util import *
@@ -188,6 +189,7 @@ def Main(args):
             if config.sys.debug:
                 session.ui.error(_('Failed to decrypt configuration, '
                                    'please log in!'))
+        HealthCheck(session, None, []).run()
         config.prepare_workers(session)
     except AccessError, e:
         session.ui.error('Access denied: %s\n' % e)

--- a/mailpile/config/defaults.py
+++ b/mailpile/config/defaults.py
@@ -31,6 +31,7 @@ CONFIG_RULES = {
     'master_key': k(_('Master symmetric encryption key'), str, ''),
     'sys': p(_('Technical system settings'), False, {
         'fd_cache_size': p(_('Max files kept open at once'), int,         500),
+        'minfree_mb':    p(_('Required free disk space (MB)'), int,      1024),
         'history_length': (_('History length (lines, <0=no save)'), int,  100),
         'http_host':     p(_('Listening host for web UI'),
                            'hostname', 'localhost'),

--- a/mailpile/mail_source/__init__.py
+++ b/mailpile/mail_source/__init__.py
@@ -198,6 +198,11 @@ class BaseMailSource(threading.Thread):
             return mbx.path
 
     def _check_interrupt(self, log=True, clear=True):
+        if not self._interrupt:
+            full_path = self.session.config.need_more_disk_space()
+            if full_path is not None:
+                self._interrupt = _('Insufficient free space in %s'
+                                    ) % full_path
         if (mailpile.util.QUITTING or
                 self._interrupt or
                 not self.my_config.enabled):

--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -3,16 +3,18 @@
 # Misc. utility functions for Mailpile.
 #
 import cgi
+import ctypes
 import datetime
 import hashlib
 import inspect
 import locale
+import os
+import platform
 import random
 import re
-import subprocess
-import os
-import sys
 import string
+import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -740,6 +742,19 @@ def backup_file(filename, backups=5, min_age_delta=0):
                     os.remove(nbf)
                 os.rename(bf, nbf)
         os.rename(filename, '%s.1' % filename)
+
+
+# Thanks to:
+# https://stackoverflow.com/questions/51658/cross-platform-space-remaining-on-volume-using-python
+def get_free_disk_bytes(dirname):
+    """Return folder/drive free space in bytes"""
+    if platform.system().lower().startswith('win'):
+        free_bytes = ctypes.c_ulonglong(0)
+        ctypes.windll.kernel32.GetDiskFreeSpaceExW(ctypes.c_wchar_p(dirname), None, None, ctypes.pointer(free_bytes))
+        return free_bytes.value
+    else:
+        st = os.statvfs(dirname)
+        return st.f_bavail * st.f_frsize
 
 
 def json_helper(obj):

--- a/shared-data/default-theme/html/jsapi/ui/notifications.js
+++ b/shared-data/default-theme/html/jsapi/ui/notifications.js
@@ -312,3 +312,13 @@ EventLog.subscribe('.*compose.Sendit', function(ev) {
   }
   Mailpile.notification(ev);
 });
+EventLog.subscribe('.*HealthCheck', function(ev) {
+  if (ev.data.healthy) {
+    ev.icon = 'icon-checkmark';
+  }
+  else {
+    ev.icon = 'icon-signature-unknown';
+    ev.timeout = 120000;
+  }
+  Mailpile.notification(ev);
+});


### PR DESCRIPTION
Changes:

   * Add a sys.minfree_mb variable for configuring our space requirements
   * Under sys.minfree_mb, stop downloading and indexing mail
   * Under sys.minfree_mb/2, make Mailpile completely read-only
   * Add a HealthCheck command, add notifications in the UI

The HealthCheck command is mostly used internally, but can be invoked from
the CLI if the user is curious. It communicates and keeps state in the Event
Log.

This method will probably be expanded later as other "system health" issues
are identified which we want to check for; this could include low RAM or
reminders to the user about making/enabling backups.