### PR TITLE
[wip] fix gpg key generation in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.10
+FROM ubuntu:14.04
 
 # Install dependencies
 RUN apt-get update -y && \


### PR DESCRIPTION
go back to ubuntu 14.04 to install gnupg 1.4 instead of gnupg 2

not tested, this is not to be merged yet