### PR TITLE
Use urlparse for URL parsing

### DIFF
--- a/mailpile/auth.py
+++ b/mailpile/auth.py
@@ -122,9 +122,8 @@ class Authenticate(Command):
 
         # These are here to prevent people from abusing this to redirect to
         # arbitrary URLs on the Internet.
-        assert('://' not in path)          # https://, http://, ftp://, ...
-        assert(path[:2] != '//')           # //www.example.com/
-        assert('/' in path.split(':')[0])  # mailto:user@example.com
+        url = urlparse(path)
+        assert(not url.scheme and not url.netloc)
 
         if (path and
                not path[1:].startswith(DeAuthenticate.SYNOPSIS[2] or '!') and


### PR DESCRIPTION
Rather than split() collection

refs #1695 #1582