### PR TITLE
Improvements to setting and changing passwords

### DIFF
--- a/mailpile/auth.py
+++ b/mailpile/auth.py
@@ -174,7 +174,7 @@ class Authenticate(Command):
 
             except (AssertionError, IOError):
                 session.ui.debug('Bad passphrase for %s' % session_id)
-                return self._error(_('Invalid passphrase, please try again'))
+                return self._error(_('Invalid password, please try again'))
 
         if user in config.logins or user == 'DEFAULT':
             # FIXME: Salt and hash the password, check if it matches

--- a/mailpile/auth.py
+++ b/mailpile/auth.py
@@ -77,6 +77,11 @@ SESSION_CACHE = UserSessionCache()
 LOGIN_FAILURES = []
 
 
+def LogoutAll():
+    for k in list(SESSION_CACHE.keys()):
+        del SESSION_CACHE[k]
+
+
 class Authenticate(Command):
     """Authenticate a user (log in)"""
     SYNOPSIS = (None, 'login', 'auth/login', None)

--- a/mailpile/auth.py
+++ b/mailpile/auth.py
@@ -299,8 +299,13 @@ class SetPassphrase(Command):
             return self._success(_('Enter your password'), result)
 
         assert(keyid is not None and fingerprint is not None)
+        if fingerprint in config.secrets:
+            if config.secrets[fingerprint].policy == 'protect':
+                return self._error(_('Protected password'), result)
+
         def happy(msg):
-            # Fun side effect: changing the passphrase invalidates the message cache
+            # Fun side effect: changing the passphrase invalidates the
+            # message cache
             import mailpile.mailutils
             mailpile.mailutils.ClearParseCache(full=True)
 

--- a/mailpile/config/defaults.py
+++ b/mailpile/config/defaults.py
@@ -150,7 +150,7 @@ CONFIG_RULES = {
     'secrets': [_('Secrets the user wants saved'), {
         'password':        (_('A secret'), str, ''),
         'policy':          (_('Security policy'),
-                            ["store", "cache-only", "fail"],
+                            ["store", "cache-only", "fail", "protect"],
                             'store')
     }, {}],
     'routes': [_('Outgoing message routes'), {

--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -264,6 +264,11 @@ class ConfigManager(ConfigDict):
     def load(self, session, *args, **kwargs):
         from mailpile.plugins.core import Rescan
 
+        # This should happen somewhere, may as well happen here. We don't
+        # rely on Python's random for anything important, but it's still
+        # nice to seed it well.
+        random.seed(os.urandom(8))
+
         keep_lockdown = self.sys.lockdown
         with self._lock:
             rv = self._unlocked_load(session, *args, **kwargs)

--- a/mailpile/plugins/contacts.py
+++ b/mailpile/plugins/contacts.py
@@ -990,7 +990,9 @@ def ProfileVCard(parent):
                     event.message = _('PGP key generation is complete')
 
                 # Record the passphrase!
-                config.secrets[fingerprint] = {'password': passphrase}
+                config.secrets[fingerprint] = {
+                    'password': passphrase,
+                    'policy': 'protect'}
 
                 # FIXME: Toggle something that indicates we need a backup ASAP.
                 self._background_save(config=True)

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -1094,6 +1094,7 @@ class SetupPassword(TestableWebbable):
                         config.prefs.gpg_recipient = '!PASSWORD'
                         self.make_master_key()
                         self._background_save(config=True)
+                        mailpile.auth.LogoutAll()
                         done = True
                 else:
                     mismatch = True

--- a/mailpile/security.py
+++ b/mailpile/security.py
@@ -266,6 +266,7 @@ class SecurePassphraseStorage(object):
         # primitive in-memory obfuscation relying on how Python represents
         # small integers as globally shared objects. Better Than Nothing!
         self.data = string_to_intlist(passphrase)
+        self.stretch_cache = {}
         self.generation += 1
 
     def compare(self, passphrase):

--- a/shared-data/default-theme/html/auth/shared.html
+++ b/shared-data/default-theme/html/auth/shared.html
@@ -31,7 +31,7 @@ Decrypting Index, Messages, and Contacts
     <button type="submit" class="submit"><span class="icon-key"></span></button>
   </form>
   {% if status_message == 'error' %}
-  <div class="login-wrong-passphrase animated bounceIn">{{_("Oops, wrong passphrase. Try again?")}}</div>
+  <div class="login-wrong-passphrase animated bounceIn">{{_("Oops, wrong password. Try again?")}}</div>
   {% elif result.login_failures|length %}
   <div class="logged-out-message animated bounceIn">{{_("Last failed login:")}}
     {{ result.login_failures[-1]|friendly_time }}

--- a/shared-data/default-theme/html/jsapi/global/silly.js
+++ b/shared-data/default-theme/html/jsapi/global/silly.js
@@ -67,7 +67,7 @@ Mailpile.silly_strings = {
     '{{_("All of your config settings & passwords are encrypted with AES-256")|escapejs}}',
     '{{_("Encrypting e-mails means your communication actually stays private")|escapejs}}',
     '{{_("The more encrypted e-mail you send, the better!")|escapejs}}',
-    '{{_("Make sure you print or save your keys & passphrase somewhere secure")|escapejs}}',
+    '{{_("Make sure you print or save your keys & passwords somewhere secure")|escapejs}}',
     '{{_("Mailpile by default encrypts your search index!")|escapejs}}',
     '{{_("The most common e-mail password is 123456, hopefully yours is different")|escapejs}}'
   ],

--- a/shared-data/default-theme/html/partials/pile_message.html
+++ b/shared-data/default-theme/html/partials/pile_message.html
@@ -193,9 +193,9 @@
 $(document).ready(function() {
   Mailpile.Message.AnalyzeMessageInline('{{mid}}');
   $('#message-{{mid}}').data('html', {{ message.html_parts|json|safe }});
-{%- if message.html_parts|length > 0 and
-       from.get('html-policy', 'none') != 'none' %}
-  Mailpile.Message.ShowHTML('{{mid}}', '{{from["html-policy"]}}');
- {%- endif %}
+  {%- if message.html_parts|length > 0 and
+         from.get('html-policy', 'none') != 'none' %}
+    Mailpile.Message.ShowHTML('{{mid}}', '{{from["html-policy"]}}');
+  {%- endif %}
 });
 </script>

--- a/shared-data/default-theme/html/settings/privacy.html
+++ b/shared-data/default-theme/html/settings/privacy.html
@@ -298,6 +298,12 @@
         {{_("Encryption makes it harder to migrate your data to another e-mail client, slows things down and may increase the odds of data loss.")}}
         {{_("Losing your encryption key becomes equivalent to losing all your mail.")}}
       </p>
+      <p class="risks">
+        <span class="icon icon-key"></span>
+        {{_("Also keep in mind that the security of your data depends entirely on the strength of your password.")}}
+        <br>
+        <a href="/setup/password/">{{ _("You can change your Mailpile password here.") }}</a>
+      </p>
     </div>
     <div class="settings">
 

--- a/shared-data/default-theme/html/settings/set/password/index.html
+++ b/shared-data/default-theme/html/settings/set/password/index.html
@@ -100,7 +100,7 @@
           <input id="input-setup-passphrase_confirm"
                  class="medium center" type="password" name="password"
                  autocorrect="off" autocapitalize="off"
-                 placeholder="top secret super duper passphrase" tabindex="3">
+                 placeholder="top secret super duper password" tabindex="3">
         </span>
       </div>
       <button class="button-primary" type="submit">{{_("Unlock Encryption Key")}}</button>

--- a/shared-data/default-theme/html/setup/password/index.html
+++ b/shared-data/default-theme/html/setup/password/index.html
@@ -33,41 +33,127 @@
       {{ csrf_field|safe }}
       <h3 class="text-center">{{_("Change your password")}}</h3>
       <span id="validation-passphrase">
-        <label class="validation-message">{{_("Authenticate")}}</label>
+        <label class="validation-message" {% if result.incorrect %}style="color: #f00;"{% endif %}>{{_("Authenticate")}}</label>
         <span class="validation-message"></span>
-        <input id="input-setup-passphrase" class="medium center"
-               type="password" name="existing"
+        <input id="input-setup-validate-passphrase" class="medium center"
                autofocus autocorrect="off" autocapitalize="off" class="center"
-               placeholder="{{_("your current password")}}">
+      {% if result.incorrect %}
+               placeholder="{{_("Password incorrect! Try again...")}}"
+      {% else %}
+               placeholder="{{_("your current password")}}"
+      {% endif %}
+               type="password" name="existing">
       </span>
-      <label class="validation-message">{{_("Choose a password")}}</label>
+      <a id="generate" title="{{ _("Click to generate new secure password") }}">
+        <label class="validation-message">
+          {{_("Choose a new password")}}
+          &nbsp;&nbsp; <span class="icon icon-robot"></span>
+        </label>
+      </a>
     {% else %}
-      <h3 class="text-center">{{_("Choose a password")}}</h3>
-      <p class="text-center">
+      <h3 class="text-center">
+        {{_("Choose a password")}}
+      </h3>
+      <p class="text-center about">
         {{_("Your password should be something really hard to guess but memorable.")}}<br>
         {{_("This password will be used to unlock your Mailpile.")}}
       </p>
     {% endif %}
 
+      <p class="hide blank"><i>
+        {{_("We have made a secure recommendation, but you still need to type it yourself!")}}
+      </i></p>
+      <p class="hide mismatch"><i>
+        {{_("The passphrases don't match!")}}
+      </i></p>
+      <p class="hide short"><i>
+        {{_("That passphrase is too short. This is important!")}}
+      </i></p>
+      <p class="hide shortish"><i>
+        {{_("That password is a bit short!")}}<br>
+        {{_("We recommend using a phrase of at least four memorable words.")}}
+      </i></p>
+
+      {% set suggestion = mailpile('setup/mkpass').result.passphrase %}
       <span id="validation-passphrase">
         <span class="validation-message"></span>
         <input id="input-setup-passphrase" class="medium center"
                type="password" name="password1"
                autofocus autocorrect="off" autocapitalize="off" class="center"
-               placeholder="{{_("very important secret password")}}">
+               placeholder="{{ suggestion }}">
       </span>
       <span id="validation-passphrase_confirm">
         <label class="validation-message">{{_("Confirm your password")}}</label>
         <input id="input-setup-passphrase_confirm" class="medium center"
                type="password" name="password2"
                autocorrect="off" autocapitalize="off" class="center"
-               placeholder="{{_("very important secret password")}}">
+               placeholder="{{ suggestion }}">
       </span>
 
       <button id="btn-setup-passphrase" class="button-primary"
               type="submit">{{_("Set Password")}}</button>
+
+    {% if result.need_password %}
+      <a style="position: absolute; opacity: 0.6; margin-top: 5px" href="/">
+        &nbsp; &nbsp; &nbsp;
+        <span class="icon icon-home"></span> {{_("Cancel")}}
+      </a>
+    {% else %}
+      <a id="generate"
+         style="position: absolute; opacity: 0.6; margin-top: 5px"
+         title="{{ _("Click to generate new secure password") }}">
+        &nbsp; &nbsp; &nbsp;
+        <span class="icon icon-robot"></span> {{_("Suggest")}}
+      </a>
+    {% endif %}
+
     </form>
   </div>
-
 </div>
+
+<script type="text/javascript">
+  $(document).ready(function() {
+    $('a#generate').click(function() {
+      Mailpile.API.setup_mkpass_post({}, function(response){
+        $('input#input-setup-passphrase, input#input-setup-passphrase_confirm'
+          ).attr('placeholder', response.result.passphrase);
+      });
+    });
+
+    var $pw1 = $('input#input-setup-passphrase');
+    var $pw2 = $('input#input-setup-passphrase_confirm');
+
+    $pw2.focus(function(ev) {
+      if ($pw1.val().length <= 16) {
+        $('.about, .blank, .mismatch, .short').slideUp();
+        $('.shortish').slideDown();
+      }
+      else {
+        $('.shortish, .blank, .mismatch, .short').slideUp();
+        $('.about').slideDown();
+      }
+    });
+
+    $('form').submit(function(ev) {
+      if (!$pw1.val())
+      {
+        $('.about, .mismatch, .short').slideUp();
+        $('.blank').slideDown();
+        ev.preventDefault();
+      }
+      else if ($pw1.val() != $pw2.val())
+      {
+        $('.about, .blank, .short').slideUp();
+        $('.mismatch').slideDown();
+        ev.preventDefault();
+      }
+      else if ($pw1.val().length <= 6)
+      {
+        $('.about, .blank, .mismatch').slideUp();
+        $('.short').slideDown();
+        ev.preventDefault();
+      }
+    });
+  });
+</script>
 {% endblock %}

--- a/shared-data/default-theme/html/setup/password/index.html
+++ b/shared-data/default-theme/html/setup/password/index.html
@@ -64,10 +64,10 @@
         {{_("We have made a secure recommendation, but you still need to type it yourself!")}}
       </i></p>
       <p class="hide mismatch"><i>
-        {{_("The passphrases don't match!")}}
+        {{_("The passwords don't match!")}}
       </i></p>
       <p class="hide short"><i>
-        {{_("That passphrase is too short. This is important!")}}
+        {{_("That password is too short. This is important!")}}
       </i></p>
       <p class="hide shortish"><i>
         {{_("That password is a bit short!")}}<br>

--- a/shared-data/default-theme/html/setup/password/index.html
+++ b/shared-data/default-theme/html/setup/password/index.html
@@ -30,6 +30,7 @@
           id="form-setup-passphrase" class="standard text-center half-top">
 
     {% if result.need_password %}
+      {{ csrf_field|safe }}
       <h3 class="text-center">{{_("Change your password")}}</h3>
       <span id="validation-passphrase">
         <label class="validation-message">{{_("Authenticate")}}</label>


### PR DESCRIPTION
This addresses the most pressing password-set/change deficiencies of the app:

1. Makes it possible to change the password after setup
2. Provides basic feedback in the UI about password strength (length only atm)
3. Provide strongly random password suggestions
4. Get rid of any mention of "passphrase" in the UI, just use the word "password" everywhere.
5. Ensure changing the master password logs out all sessions authed using old credentials
6. Prevent the key lock/unlock tool from bricking keys generated by Mailpile itself
7. Make sure that old passwords aren't kept forever on disk after changing (they are kept for a little while, so users can revert the change if necessary)

   