### PR TITLE
Added grunt as a dev dependency (rather than grunt-cli)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mailpile",
   "version": "0.4.1",
-  "dependencies": {
-    "grunt-cli": "latest",
+  "devDependencies": {
+    "grunt": "latest",
     "grunt-contrib-concat": "latest",
     "grunt-contrib-uglify": "latest",
     "grunt-contrib-less": "latest",


### PR DESCRIPTION
Without the grunt dependency, trying to run a grunt task results in `Fatal error: Unable to find local grunt.`

grunt-cli is supposed to be installed globally (`npm i -g grunt-cli`) rather than as a project dependency.