### PR TITLE
bugfix: re.search only works on string type data, cast any other type…

### DIFF
--- a/mailpile/httpd.py
+++ b/mailpile/httpd.py
@@ -83,7 +83,7 @@ class HttpRequestHandler(SimpleXMLRPCRequestHandler):
     _HTML_RE = re.compile('[<>\'\"]+')
 
     def assert_no_newline(self, data):
-        assert(re.search(self._NEWLINE_RE, data or '') is None)
+        assert(re.search(self._NEWLINE_RE, str(data) or '') is None)
 
     def assert_no_html(self, data):
         assert(re.search(self._HTML_RE, data or '') is None)


### PR DESCRIPTION
I'm not really wise enough to figure out where to cast best... #1735 