### PR TITLE
Fix CSS for crypto header of inline composer

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -8227,7 +8227,6 @@ tr.modal-tag-picker-item td.checkbox {
   overflow: hidden;
   word-wrap: normal;
   word-break: normal;
-  white-space: nowrap;
 }
 #pile-results td.subject a.item-subject {
   width: 370px;

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -115,7 +115,6 @@
     overflow: hidden;
     word-wrap: normal;
     word-break: normal;
-    white-space: nowrap;
   }
 
   #pile-results td.subject a.item-subject {


### PR DESCRIPTION
There was a CSS bug, the crypto header was floating around in the composer when
composing in the thread/inline view.

For the story, I had to PR #1682 and #1738 on the way to this tiny one-line PR :-)

Before:

![screenshot-localhost 33411 2016-12-31 01-23-25](https://cloud.githubusercontent.com/assets/429633/21574719/55e8a044-cef8-11e6-9b70-f09d03cbff7a.png)

After:

![screenshot-localhost 33411 2016-12-31 01-23-47](https://cloud.githubusercontent.com/assets/429633/21574723/637ac6ce-cef8-11e6-8982-5929d816f1f6.png)

