### PR TITLE
CSS fix - broken wrapping of subjects and introducing ellipsis...

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -8231,6 +8231,9 @@ tr.modal-tag-picker-item td.checkbox {
 #pile-results td.subject a.item-subject {
   width: 370px;
   display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 /* This is because relative % positioning inside a table doesn't work
    * because the table does not yet know its own size.

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -120,6 +120,9 @@
   #pile-results td.subject a.item-subject {
     width: 370px;
     display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   /* This is because relative % positioning inside a table doesn't work


### PR DESCRIPTION
...to shorten too long subject lines. This should also work with Firefox 45.