### PR TITLE
CSS - Made body overflow hidden...

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -6288,6 +6288,10 @@ div.motd a.motd-signed {
   line-height: 14px;
   color: #ffffff;
 }
+/* Body */
+body {
+  overflow:hidden;
+}
 /* Content */
 #content {
   position: fixed;

--- a/shared-data/default-theme/less/app/global.less
+++ b/shared-data/default-theme/less/app/global.less
@@ -1,3 +1,8 @@
+/* Body */
+  body {
+    overflow: hidden;
+  }
+
 /* Content */
 
   #content {


### PR DESCRIPTION
…and thereby fixes the login page growing out of screen size when logging in. I couldn't find an issue about this and didn't know if I should make a new one or not since it was such an easy fix. Anyhow, I can't see that it breaks anything, but please test it since it affects body and thereby everything.