### PR TITLE
Fixes overflow issue with very long mail addresses in notification box

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -6288,6 +6288,10 @@ div.motd a.motd-signed {
   line-height: 14px;
   color: #ffffff;
 }
+/* Body */
+body {
+  overflow: hidden;
+}
 /* Content */
 #content {
   position: fixed;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -6288,10 +6288,6 @@ div.motd a.motd-signed {
   line-height: 14px;
   color: #ffffff;
 }
-/* Body */
-body {
-  overflow: hidden;
-}
 /* Content */
 #content {
   position: fixed;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -6738,6 +6738,12 @@ div.notification-bubble span.text {
 }
 div.notification-bubble span.message {
   font-weight: bold;
+  width: 180px;
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
 }
 div.notification-bubble span.action {
   font-weight: normal;

--- a/shared-data/default-theme/less/app/global.less
+++ b/shared-data/default-theme/less/app/global.less
@@ -1,3 +1,9 @@
+/* Body */
+
+  body {
+    overflow: hidden;
+  }
+
 /* Content */
 
   #content {

--- a/shared-data/default-theme/less/app/global.less
+++ b/shared-data/default-theme/less/app/global.less
@@ -1,9 +1,3 @@
-/* Body */
-
-  body {
-    overflow: hidden;
-  }
-
 /* Content */
 
   #content {

--- a/shared-data/default-theme/less/app/notifications.less
+++ b/shared-data/default-theme/less/app/notifications.less
@@ -66,6 +66,11 @@
 
   div.notification-bubble span.message {
     font-weight: bold;
+    width: 180px;
+    display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   div.notification-bubble span.action {


### PR DESCRIPTION
When using very long email addresses, these overflowed the Notifications box. This takes care of that and makes them end with ellipsis instead of overflowing.