### PR TITLE
Raise IOError on decoding failure to avoid crashes. Issue #1762

### DIFF
--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -685,7 +685,7 @@ class ConfigManager(ConfigDict):
                 from mailpile.crypto.streamer import DecryptingStreamer
                 with DecryptingStreamer(fd,
                                         mep_key=self.master_key,
-                                        name='load_pickle'
+                                        name='load_pickle(%s)' % pfn
                                         ) as streamer:
                     rv = cPickle.loads(streamer.read())
                     streamer.verify(_raise=IOError)

--- a/mailpile/crypto/streamer.py
+++ b/mailpile/crypto/streamer.py
@@ -802,8 +802,12 @@ class DecryptingStreamer(InputCoprocess):
                             self.buffered = b
                         else:
                             d, self.buffered = self.buffered, ''
-                        data += self.decryptor(self.decoder(d))
-                        eof = False
+                        try:
+                            data += self.decryptor(self.decoder(d))
+                            eof = False
+                        except TypeError:
+                            raise IOError('%s: Bad data, failed to decode'
+                                          % self.name)
             return (data or '')
 
         if data is None:

--- a/mailpile/eventlog.py
+++ b/mailpile/eventlog.py
@@ -274,7 +274,8 @@ class EventLog(object):
         with open(os.path.join(self.logdir, lfn)) as fd:
             if enc_key:
                 with DecryptingStreamer(fd, mep_key=enc_key,
-                                        name='EventLog/DS') as streamer:
+                                        name='EventLog/DS(%s)' % lfn
+                                        ) as streamer:
                     lines = streamer.read()
                     streamer.verify(_raise=IOError)
             else:

--- a/mailpile/mailboxes/wervd.py
+++ b/mailpile/mailboxes/wervd.py
@@ -71,10 +71,12 @@ class MailpileMailbox(UnorderedPicklable(mailbox.Maildir, editable=True)):
 
     def _get_fd(self, key):
         with self._lock:
-            fd = open(os.path.join(self._path, self._lookup(key)), 'rb')
+            fn = os.path.join(self._path, self._lookup(key))
             mep_key = self._decryption_key_func()
+        fd = open(fn, 'rb')
         if mep_key:
-            fd = DecryptingStreamer(fd, mep_key=mep_key, name='WERVD')
+            fd = DecryptingStreamer(fd, mep_key=mep_key,
+                                    name='WERVD(%s)' % fn)
         return fd
 
     def get_message(self, key):

--- a/mailpile/vcard.py
+++ b/mailpile/vcard.py
@@ -872,7 +872,8 @@ class MailpileVCard(SimpleVCard):
             with open(self.filename, 'rb') as fd:
                 with DecryptingStreamer(fd,
                                         mep_key=self.decryption_key_func(),
-                                        name='VCard/load') as streamer:
+                                        name='VCard/load(%s)' % self.filename
+                                        ) as streamer:
                     data = streamer.read().decode('utf-8')
                     streamer.verify(_raise=IOError)
         else:


### PR DESCRIPTION
This converts the TypeError raised by the Base64 decoder into an
IOError, which is generally handled appropriately by the invoking
code and shouldn't crash any threads.

Also added some more detailed introspection so tracebacks will
include the filename of the bogus data.