### PR TITLE
Fix key generation in docker (#1785)

### DIFF
--- a/mailpile/crypto/gpgi.py
+++ b/mailpile/crypto/gpgi.py
@@ -1651,7 +1651,7 @@ class GnuPG21KeyGenerator(GnuPG14KeyGenerator):
     def gpg_args(self):
         # --yes should keep GnuPG from complaining if there already exists
         #       a key with this UID.
-        return ['--yes', '--full-generate-key']
+        return ['--yes', '--full-gen-key']
 
 
 class GnuPGDummyKeyGenerator(GnuPGBaseKeyGenerator):


### PR DESCRIPTION
Falls back on old GPG flag for interactive generation of keys. Fixes key generation when running in docker. Closes #1785.