### PR TITLE
Docker: Mount code + config inside the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,52 @@ FROM ubuntu:16.10
 
 # Install dependencies
 RUN apt-get update -y && \
-    apt-get install -y openssl python-imaging python-jinja2 python-lxml libxml2-dev libxslt1-dev python-pgpdump python-cryptography spambayes tor
+    apt-get install -y openssl \
+                       python-pip \
+                       python-imaging \
+                       python-jinja2 \
+                       python-lxml \
+                       libxml2-dev \
+                       libxslt1-dev \
+                       python-pgpdump \
+                       python-cryptography \
+                       spambayes \
+                       tor
 
-# Add code
-WORKDIR /Mailpile
+# Add mailpile code (required for initial setup, not for develpoment)
 ADD . /Mailpile
 
-# Create users and groups
-RUN groupadd -r mailpile \
-    && mkdir -p /mailpile-data/.gnupg \
-    && useradd -r -d /mailpile-data -g mailpile mailpile
+# Create data dir
+# This will be overriden by a volume hosted by the docker host (your dev machine)
+RUN mkdir /mailpile-data
 
-# Add GnuPG placeholder file
-RUN touch /mailpile-data/.gnupg/docker_placeholder
+# Create mailpile user and group.
+RUN groupadd -r mailpile && \
+    useradd -r -d /mailpile-data -g mailpile mailpile
 
-# Fix permissions
+# Workaround: Setting mailpile users uid to 1000 to have write permissions
+# from the docker host the to the shared volumes /Mailpile and /mailpile-data.
+# Mounted volumes seem to be configured w/ uid/guid = 1000.
+# Learn more here:
+# - https://github.com/docker/docker/issues/7198
+# - https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
+RUN usermod -u 1000 mailpile
+
+# Fix permissions for dirs (w/o they would only be accessible for root)
 RUN chown -R mailpile:mailpile /Mailpile
 RUN chown -R mailpile:mailpile /mailpile-data
 
-# Run as non-privileged user
+# Set /Mailpile as root dir for further RUN cmds
+WORKDIR /Mailpile
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements-dev.txt
+
+# Run as mailpile user
 USER mailpile
 
 # Initialize mailpile
 RUN ./mp setup
 
-# Entrypoint
-CMD ./mp --www=0.0.0.0:33411 --wait
+CMD ["./mp", "--www=0.0.0.0:33411", "--wait"]
 EXPOSE 33411
-
-# Volumes
-VOLUME /mailpile-data/.local/share/Mailpile
-VOLUME /mailpile-data/.gnupg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,11 @@
-mailpile:
-  build: .
-  ports:
-    - 33411:33411
+version: '3.0'
+services:
+  mailpile:
+    container_name: mailpile_dev
+    build: .
+    volumes:
+      - .:/Mailpile
+      - .dev-mailpile-data:/mailpile-data
+    ports:
+      - 33411:33411
+


### PR DESCRIPTION
I reallly like to work locally w/ all Mailpile code being executed in the docker container.

The sourcecode and mailpile data I'd like to keep on the docker host instead and mount it into the container, in order to: 
- have file changes immediately be reflected in the running application
- persists config when shutting the docker container down

With my change I am able now to check out the Mailpile-project and start working with a simple:

```
docker-compose up
```

Now I can edit the sourcecode on my machine and see my (front end code) changes immediately reflected inside the running application. For seeing a change in the python code to take effect I still need to restart the docker container.

Another benefit is that I keep my `/mailpile-data` and can restart the docker container w/o having to walk through the setup.

---
 
If there is anybody else also working on Mailpile w/ Docker I'd love see if they are able to work with my changes.

---

I could not find an easy way in docker/docker-compose to configure the permissions for the `/Mailpile` and `/mailpile-data` directories so that the `mailpile` user inside the docker container has proper read-write access. To work around the issue I use `usermod` to set the `mailpile` uid
to 1000.

The issue is documented inside the `Dockerfile`.
- https://github.com/docker/docker/issues/7198
- https://denibertovic.com/posts/handling-permissions-with-docker-volumes/