### PR TITLE
Docker: Mount code + config from docker host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,52 @@ FROM ubuntu:16.10
 
 # Install dependencies
 RUN apt-get update -y && \
-    apt-get install -y openssl python-imaging python-jinja2 python-lxml libxml2-dev libxslt1-dev python-pgpdump python-cryptography spambayes tor
+    apt-get install -y openssl \
+                       python-pip \
+                       python-imaging \
+                       python-jinja2 \
+                       python-lxml \
+                       libxml2-dev \
+                       libxslt1-dev \
+                       python-pgpdump \
+                       python-cryptography \
+                       spambayes \
+                       tor
 
-# Add code
-WORKDIR /Mailpile
+# Add mailpile code (required for initial setup, not for develpoment)
 ADD . /Mailpile
 
-# Create users and groups
-RUN groupadd -r mailpile \
-    && mkdir -p /mailpile-data/.gnupg \
-    && useradd -r -d /mailpile-data -g mailpile mailpile
+# Create data dir
+# This will be overriden by a volume hosted by the docker host (your dev machine)
+RUN mkdir /mailpile-data
 
-# Add GnuPG placeholder file
-RUN touch /mailpile-data/.gnupg/docker_placeholder
+# Create mailpile user and group.
+RUN groupadd -r mailpile && \
+    useradd -r -d /mailpile-data -g mailpile mailpile
 
-# Fix permissions
+# Workaround: Setting mailpile users uid to 1000 to have write permissions
+# from the docker host the to the shared volumes /Mailpile and /mailpile-data.
+# Mounted volumes seem to be configured w/ uid/guid = 1000.
+# Learn more here:
+# - https://github.com/docker/docker/issues/7198
+# - https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
+RUN usermod -u 1000 mailpile
+
+# Fix permissions for dirs (w/o they would only be accessible for root)
 RUN chown -R mailpile:mailpile /Mailpile
 RUN chown -R mailpile:mailpile /mailpile-data
 
-# Run as non-privileged user
+# Set /Mailpile as root dir for further RUN cmds
+WORKDIR /Mailpile
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements-dev.txt
+
+# Run as mailpile user
 USER mailpile
 
 # Initialize mailpile
 RUN ./mp setup
 
-# Entrypoint
-CMD ./mp --www=0.0.0.0:33411 --wait
+CMD ["./mp", "--www=0.0.0.0:33411", "--wait"]
 EXPOSE 33411
-
-# Volumes
-VOLUME /mailpile-data/.local/share/Mailpile
-VOLUME /mailpile-data/.gnupg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,33 @@
-FROM ubuntu:16.10
+FROM alpine:3.5
 
-# Install dependencies
-RUN apt-get update -y && \
-    apt-get install -y openssl \
-                       python-pip \
-                       python-imaging \
-                       python-jinja2 \
-                       python-lxml \
-                       libxml2-dev \
-                       libxslt1-dev \
-                       python-pgpdump \
-                       python-cryptography \
-                       spambayes \
-                       tor
-
-# Add mailpile code (required for initial setup, not for develpoment)
-ADD . /Mailpile
-
-# Create data dir
-# This will be overriden by a volume hosted by the docker host (your dev machine)
-RUN mkdir /mailpile-data
-
-# Create mailpile user and group.
-RUN groupadd -r mailpile && \
-    useradd -r -d /mailpile-data -g mailpile mailpile
-
-# Workaround: Setting mailpile users uid to 1000 to have write permissions
-# from the docker host the to the shared volumes /Mailpile and /mailpile-data.
-# Mounted volumes seem to be configured w/ uid/guid = 1000.
-# Learn more here:
-# - https://github.com/docker/docker/issues/7198
-# - https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
-RUN usermod -u 1000 mailpile
-
-# Fix permissions for dirs (w/o they would only be accessible for root)
-RUN chown -R mailpile:mailpile /Mailpile
-RUN chown -R mailpile:mailpile /mailpile-data
-
-# Set /Mailpile as root dir for further RUN cmds
 WORKDIR /Mailpile
 
-RUN pip install --upgrade pip
-RUN pip install -r requirements-dev.txt
+# Create users and groups
+RUN addgroup -S mailpile && adduser -S -h /mailpile-data -G mailpile mailpile
 
-# Run as mailpile user
-USER mailpile
+# Install dependencies
+RUN apk --no-cache add \
+  ca-certificates \
+  openssl \
+  gnupg1 \
+  py-pip \
+  py-imaging \
+  py-jinja2 \
+  py-lxml \
+  py-lockfile \
+  py-pillow \
+  py-pbr \
+  py-cryptography \
+  su-exec
 
-# Initialize mailpile
-RUN ./mp setup
+ADD requirements.txt /Mailpile/requirements.txt
+RUN pip install -r requirements.txt
 
-CMD ["./mp", "--www=0.0.0.0:33411", "--wait"]
+# Entrypoint
+ADD packages/docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ./mp --www=0.0.0.0:33411 --wait
 EXPOSE 33411
+
+# Add code
+ADD . /Mailpile

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,4 +19,4 @@ RUN pip install -r requirements-dev.txt
 
 RUN chmod +x /entrypoint.sh
 
-CMD ["./mp", "--www=0.0.0.0:33411", "--wait"]
+CMD ["./mp"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+FROM mailpile
+
+# Install C compiler for python deps w/ native extensions
+RUN apk --no-cache add \
+  gcc \
+  libc-dev \
+  python-dev \
+  shadow
+
+# Workaround: Setting mailpile users uid to 1000 to have write permissions
+# from the docker host the to the shared volumes /Mailpile and /mailpile-data.
+# Mounted volumes seem to be configured w/ uid/guid = 1000.
+# Learn more here:
+# - https://github.com/docker/docker/issues/7198
+# - https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
+RUN usermod -u 1000 mailpile
+
+RUN pip install -r requirements-dev.txt
+
+RUN chmod +x /entrypoint.sh
+
+CMD ["./mp", "--www=0.0.0.0:33411", "--wait"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,5 +12,5 @@ services:
       - .:/Mailpile
       - .dev-mailpile-data:/mailpile-data:rw
     ports:
-      - 33411:33411
+      - 33412:33411
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,8 @@
 version: '3.0'
 services:
   mailpile_dev:
+    tty: true
+    stdin_open: true
     container_name: mailpile_dev
     build:
       context: .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+version: '3.0'
+services:
+  mailpile_dev:
+    container_name: mailpile_dev
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    image: mailpile_dev
+    volumes:
+      - .:/Mailpile
+      - .dev-mailpile-data:/mailpile-data:rw
+    ports:
+      - 33411:33411
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 version: '3.0'
 services:
   mailpile:
-    container_name: mailpile_dev
+    container_name: mailpile
     build: .
+    image: mailpile
     volumes:
       - .:/Mailpile
       - .dev-mailpile-data:/mailpile-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,11 @@
-mailpile:
-  build: .
-  ports:
-    - 33411:33411
+version: '3.0'
+services:
+  mailpile:
+    container_name: mailpile_dev
+    build: .
+    volumes:
+      - .:/Mailpile
+      - .dev-mailpile-data:/mailpile-data
+    ports:
+      - 33411:33411
+

--- a/packages/docker/entrypoint.sh
+++ b/packages/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+chown mailpile: /mailpile-data/ -R
+
+su-exec mailpile "$@"

--- a/scripts/docker-dev/down
+++ b/scripts/docker-dev/down
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose -f docker-compose.dev.yml down

--- a/scripts/docker-dev/shell
+++ b/scripts/docker-dev/shell
@@ -1,0 +1,9 @@
+#!/bin/bash
+CONTAINER_NAME=mailpile_dev
+CONTAINER_ID=$(docker ps --filter "name=${CONTAINER_NAME}" --quiet)
+if [[ ! -z  $CONTAINER_ID ]]; then
+  echo "Connecting to docker container ${CONTAINER_NAME}:${CONTAINER_ID}"
+  docker attach $CONTAINER_NAME
+else
+  echo "Docker container ${CONTAINER_NAME} does not seem to be running. Start it with './scripts/docker-dev/up'"
+fi

--- a/scripts/docker-dev/up
+++ b/scripts/docker-dev/up
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose -f docker-compose.dev.yml up --build --remove-orphans


### PR DESCRIPTION
This updates #1798 respecting the changes in #1699

It uses two seperate Dockerfiles, one for running the application (`Dockerfile`) and one for development (`Dockerfile.dev` which builds upon the former).

The main goal of this change is that the config and code of the application are not embedded into a docker volume but mounted from the docker host. The `docker-compose.dev.yml` does exactly that.

To start a development environment one can run:

```
docker-compose -f docker-compose.dev.yml up --build
```