### PR TITLE
Prevent invalid tagging operations

### DIFF
--- a/mailpile/mail_source/__init__.py
+++ b/mailpile/mail_source/__init__.py
@@ -710,6 +710,8 @@ class BaseMailSource(threading.Thread):
                 'type': 'mailbox',
                 'parent': parent or '',
                 'label': label,
+                'flag_allow_add': False,
+                'flag_allow_del': False,
                 'icon': icon or 'icon-tag',
                 'display': 'tag' if visible else 'archive',
             })

--- a/mailpile/plugins/compose.py
+++ b/mailpile/plugins/compose.py
@@ -13,7 +13,6 @@ from mailpile.eventlog import Event
 from mailpile.i18n import gettext as _
 from mailpile.i18n import ngettext as _n
 from mailpile.plugins import PluginManager
-from mailpile.plugins.tags import Tag
 from mailpile.mailutils import ExtractEmails, ExtractEmailAndName, Email
 from mailpile.mailutils import NotEditableError, AddressHeaderParser
 from mailpile.mailutils import NoFromAddressError, PrepareMessage

--- a/mailpile/plugins/search.py
+++ b/mailpile/plugins/search.py
@@ -373,6 +373,7 @@ class SearchResults(dict):
             },
             'search_terms': session.searched,
             'index_capabilities': dict((c, True) for c in idx.CAPABILITIES),
+            'tag_capabilities': {},
             'address_ids': [],
             'message_ids': [],
             'view_pairs': view_pairs,
@@ -389,6 +390,10 @@ class SearchResults(dict):
             if search_tag_ids:
                 self['summary'] = ' & '.join([t.name for t
                                               in search_tags if t])
+            for attr in ('hides', 'editable', 'msg_only',
+                         'allow_add', 'allow_del'):
+                tags = [t for t in search_tags if t.get('flag_' + attr)]
+                self['tag_capabilities'][attr] = (len(tags) > 0)
         else:
             search_tag_ids = []
 

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -66,6 +66,7 @@ class SetupMagic(Command):
             'type': 'blank',
             'flag_editable': True,
             'flag_msg_only': True,
+            'flag_allow_add': False,
             'display': 'invisible',
             'name': _('Blank'),
         },
@@ -73,6 +74,7 @@ class SetupMagic(Command):
             'type': 'drafts',
             'flag_editable': True,
             'flag_msg_only': True,
+            'flag_allow_add': False,
             'display': 'priority',
             'display_order': 1,
             'icon': 'icon-compose',
@@ -82,6 +84,7 @@ class SetupMagic(Command):
         'Outbox': {
             'type': 'outbox',
             'flag_msg_only': True,
+            'flag_allow_add': False,
             'display': 'priority',
             'display_order': 3,
             'icon': 'icon-outbox',

--- a/mailpile/plugins/tags.py
+++ b/mailpile/plugins/tags.py
@@ -37,6 +37,8 @@ _plugins.register_config_section('tags', ["Tags", {
     'flag_hides': ['Hide tagged messages from searches?', 'bool', False],
     'flag_editable': ['Mark tagged messages as editable?', 'bool', False],
     'flag_msg_only': ['Never apply to entire conversations', 'bool', False],
+    'flag_allow_add': ['Allow users to apply this tag', 'bool', True],
+    'flag_allow_del': ['Allow users to remove this tag', 'bool', True],
 
     # Tag display attributes for /in/tag or searching in:tag
     'template': ['Default tag display template', 'str', 'index'],
@@ -263,7 +265,7 @@ class TagCommand(Command):
 
 class Tag(TagCommand):
     """Add or remove tags on a set of messages"""
-    SYNOPSIS = (None, 'tag', 'tag', '[--conversations|--messages] '
+    SYNOPSIS = (None, 'tag', 'tag', '[--conversations|--messages|--force] '
                                     '<[+|-]tags> <msgs>')
     ORDER = ('Tagging', 0)
     HTTP_CALLABLE = ('POST', )
@@ -272,7 +274,8 @@ class Tag(TagCommand):
         'add': 'tags',
         'del': 'tags',
         'conversations': '[yes|no|auto]',
-        'context': 'search context, for tagging relative results'
+        'context': 'search context, for tagging relative results',
+        'force': 'Force changes'
     }
     COMMAND_SECURITY = security.CC_TAG_EMAIL
 
@@ -305,6 +308,7 @@ class Tag(TagCommand):
         adding = set(self.data.get('add', []))
         ops = (['-%s' % t for t in (deling-adding) if t] +
                ['+%s' % t for t in (adding-deling) if t])
+        force = truthy(self.data.get('force', ['no'])[0])
         conversations = truthy(self.data.get('conversations', ['auto'])[0],
                                special={'auto': None})
         if 'mid' in self.data:
@@ -314,6 +318,8 @@ class Tag(TagCommand):
                 op = words.pop(0)
                 if op in ('--conversations', '--messages'):
                     conversations = True if (op[:3] == '--c') else False
+                elif op == '--force':
+                    force = True
                 else:
                     ops.append(op)
 
@@ -336,13 +342,15 @@ class Tag(TagCommand):
         msg_ids = self._choose_messages(words)
         return expanded_ops, msg_ids, conversations
 
-    def _do_tagging(self, ops, msg_ids, conversations, save=True, auto=False):
+    def _do_tagging(self, ops, msg_ids, conversations,
+                    save=True, auto=False, force=False):
         idx = self._idx()
         rv = {
             'conversations': False,
             'msg_ids': [b36(i) for i in msg_ids],
             'tagged': [],
-            'untagged': []
+            'untagged': [],
+            'ignored': []
         }
 
         for op in ops:
@@ -361,28 +369,44 @@ class Tag(TagCommand):
                 if conversation:
                     rv['conversations'] = True
 
+                ignored = False
                 tag_id = tag._key
+                tag_cfg = tag
                 tag = tag.copy()
                 tag["tid"] = tag_id
                 if op[0] == '-':
-                    removed = idx.remove_tag(self.session, tag_id,
-                                             msg_idxs=msg_ids,
-                                             conversation=conversation)
-                    rv['untagged'].append((tag, sorted([b36(i)
-                                                        for i in removed])))
+                    if force or tag_cfg['flag_allow_del']:
+                        removed = idx.remove_tag(self.session, tag_id,
+                                                 msg_idxs=msg_ids,
+                                                 conversation=conversation)
+                        rv['untagged'].append(
+                            (tag, sorted([b36(i) for i in removed])))
+                    else:
+                        rv['ignored'].append((op, tag))
+                        ignored = True
                 else:
-                    added = idx.add_tag(self.session, tag_id,
-                                        msg_idxs=msg_ids,
-                                        conversation=conversation)
-                    rv['tagged'].append((tag, sorted([b36(i)
-                                                      for i in added])))
+                    if force or tag_cfg['flag_allow_add']:
+                        added = idx.add_tag(self.session, tag_id,
+                                            msg_idxs=msg_ids,
+                                            conversation=conversation)
+                        rv['tagged'].append(
+                            (tag, sorted([b36(i) for i in added])))
+                    else:
+                        rv['ignored'].append((op, tag))
+                        ignored = True
+
                 # Record behavior
-                if len(msg_ids) < 15:
+                if len(msg_ids) < 15 and not ignored:
                     for t in self.session.config.get_tags(type='tagged',
                                                           default=[]):
                         idx.add_tag(self.session, t._key, msg_idxs=msg_ids)
             else:
                 self.session.ui.warning('Unknown tag: %s' % op)
+
+
+        if rv['ignored'] and (len(rv['tagged']) == len(rv['untagged']) == 0):
+            self.event.private_data['ignored'] = rv['ignored']
+            return self._error(_('Nothing Happened'), result=rv)
 
         if rv['conversations']:
             undo_msg = _n('Untag %d conversation',
@@ -397,11 +421,14 @@ class Tag(TagCommand):
             done_msg = _n('Tagged %d message',
                           'Tagged %d messages', len(msg_ids)) % len(msg_ids)
 
+        rv['undo_msg'] = undo_msg
         self.event.data['undo'] = undo_msg
         self.event.private_data['undo'] = {
             'tagged': [[t['tid'], mids] for t, mids in rv['tagged']],
             'untagged': [[t['tid'], mids] for t, mids in rv['untagged']],
         }
+        if rv['ignored']:
+            self.event.private_data['ignored'] = rv['ignored']
 
         self.finish(save=save)
         return self._success(done_msg, rv)
@@ -735,7 +762,7 @@ class DeleteTag(TagCommand):
 
 class TagAutomation(Command):
     """Perform automatically scheduled tasks for one or more tags"""
-    SYNOPSIS = (None, 'tags/auto', 'tags/auto', '[-force|-test] <-all|tags ...>')
+    SYNOPSIS = (None, 'tags/auto', 'tags/auto', '[--force|--test] <-all|tags ...>')
     ORDER = ('Tagging', 9)
     HTTP_CALLABLE = ('POST', )
     HTTP_POST_VARS = {}
@@ -770,8 +797,8 @@ class TagAutomation(Command):
         session, config = self.session, self.session.config
         args = list(self.args)
 
-        force = '-force' in args
-        dry_run = '-test' in args
+        force = ('-force' in args) or ('--force' in args)
+        dry_run = ('-test' in args) or ('--test' in args)
 
         today = time.time() // (24 * 3600)
         results = []

--- a/shared-data/default-theme/html/jsapi/search/init.js
+++ b/shared-data/default-theme/html/jsapi/search/init.js
@@ -6,8 +6,11 @@ Mailpile.Search.Tooltips = {};
 Mailpile.Search.init = function() {
 
   // Drag Items
-  Mailpile.UI.Search.Draggable('td.draggable');
-  Mailpile.UI.Search.Dropable('.pile-results tr', 'a.sidebar-tag');
+  var index_capabilities = $('.pile-results').data('index-capabilities');
+  if (index_capabilities.indexOf('has_tags') >= 0) {
+    Mailpile.UI.Search.Draggable('td.draggable');
+    Mailpile.UI.Search.Dropable('.pile-results tr', 'a.sidebar-tag');
+  };
 
   // Render Display Size
   if (!Mailpile.local_storage['view_size']) {

--- a/shared-data/default-theme/html/jsapi/ui/notifications.js
+++ b/shared-data/default-theme/html/jsapi/ui/notifications.js
@@ -101,7 +101,7 @@ Mailpile.notification = function(result) {
     result.icon = 'icon-signature-unknown';
   }
   else if (result.command === 'tag') {
-    result.undo = true;
+    result.undo = (result.status == "success");
     result.icon = 'icon-tag';
   }
   else if (result.source && result.source.indexOf('.mail_source.') == 0) {

--- a/shared-data/default-theme/html/partials/tools_search.html
+++ b/shared-data/default-theme/html/partials/tools_search.html
@@ -125,13 +125,15 @@
     </a>
   </li>') -%}
 {%-   endif %}
-{%-   do search_actions.append('
+{%-   if result.tag_capabilities.allow_del -%}
+{%-     do search_actions.append('
   <li class="hide">
     <a class="bulk-action-tag-op" href="#" title="' + _("Untag Selection") + '"
        data-op="untag">
       <span class="icon icon-circle-x"></span>
     </a>
   </li>') -%}
+{%-   endif %}
 {%-   do search_actions.append('
   <li class="hide">
     <a class="bulk-action-tag-op" href="#" data-op="archive"

--- a/shared-data/default-theme/html/search/index.html
+++ b/shared-data/default-theme/html/search/index.html
@@ -17,6 +17,12 @@
                       {{ config.tags[tid].name }}
                       {%- if not loop.last %}, {% endif %}
                     {%- endfor %}"
+         data-index-capabilities="{% for c in result.index_capabilities %}
+                                    {%- if result.index_capabilities[c] %}{{ c }} {% endif -%}
+                                  {%- endfor %}"
+         data-tag-capabilities="{% for c in result.tag_capabilities %}
+                                  {%- if result.tag_capabilities[c] %}{{ c }} {% endif -%}
+                                {%- endfor %}"
          class="pile-results {{ config.web.display_density }}">
   <tbody>
  {% if not result.data or not result.data.messages %}

--- a/shared-data/default-theme/html/tags/sidebar.html
+++ b/shared-data/default-theme/html/tags/sidebar.html
@@ -12,7 +12,7 @@
     class="sidebar-tag sidebar-tags-default {% if tag.stats.all == 0 %} hide{% endif %}">
 {%  else %}
 <li id="sidebar-tag-{{tag.tid}}" data-slug="{{tag.slug}}" data-tid="{{tag.tid}}" data-display_order="{{tag.display_order}}"
-    class="sidebar-tag sidebar-tags-draggable{% if tag.display == "archive" %} hide should-hide{% endif %}">
+    class="sidebar-tag sidebar-tags-{% if tag.flag_allow_add %}draggable{% else %}default{% endif %}{% if tag.display == "archive" %} hide should-hide{% endif %}">
 {%  endif %}
 
 {%- if tag.slug == "outbox" or tag.slug == "drafts" %}
@@ -51,7 +51,7 @@
 {%   for subtag in tag.subtags if subtag.display in ('tag', 'archive') %}
 <li id="sidebar-tag-{{subtag.tid}}"
     data-tid="{{subtag.tid}}" data-display_order="{{subtag.display_order}}"
-    class="sidebar-subtag sidebar-tags-draggable subtag-of-{{tag.tid}}
+    class="sidebar-subtag sidebar-tags-{% if subtag.flag_allow_add %}draggable{% else %}default{% endif %} subtag-of-{{tag.tid}}
            {%- if subtags_collapsed or 'archive' in (subtag.display, tag.display) %} hide should-hide{% endif %}">
   <a href="{{subtag.url}}" class="sidebar-tag {% if subtag.stats.new %}has-unread{% endif %} {{ navigation_on(result.search_tag_ids, subtag.tid) }}" title="{{subtag.name}} {{subtag.stats.all}}" data-tid="{{subtag.tid}}">
     <span class="icon {{subtag.icon}}" style="color: {{theme_settings().colors[subtag.label_color]}};"></span>


### PR DESCRIPTION
This PR prevents certain invalid or dangerous tagging operations in the default UI; things like manually adding Drafts or trying to tag messages that haven't been indexed yet. These ops could result in user confusion or even internal data corruption.

This PR mostly addresses the low level concerns, while also fixing part of the UI. The UI side will still need more work later on, in particular it's not immediately obvious when dragging/dropping of tags or messages is expected to fail.