### PR TITLE
Fix problems with old PGP-encrypted metadata indexes

### DIFF
--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -168,9 +168,10 @@ class MailIndex(BaseIndex):
                                              'block of index ending at %d'
                                              % offset)
                     # FIXME: Differentiate between partial index and no index?
+                    gpgi = GnuPG(self.config, event=GetThreadEvent())
                     decrypt_and_parse_lines(fd, process_lines, self.config,
-                                            newlines=True, decode=False,
-                                            _raise=False, error_cb=warn)
+                        newlines=True, decode=False, gpgi=gpgi,
+                        _raise=False, error_cb=warn)
         except IOError:
             if session:
                 session.ui.warning(_('Metadata index not found: %s'

--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -211,18 +211,19 @@ class MailIndex(BaseIndex):
         tokeys = ([gpgr]
                   if gpgr not in (None, '', '!CREATE', '!PASSWORD')
                   else None)
-        if tokeys:
-            stat, edata = GnuPG(self.config, event=GetThreadEvent()
-                                ).encrypt(data, tokeys=tokeys)
-            if stat == 0:
-                return edata
 
-        elif self.config.master_key:
+        if self.config.master_key:
             with EncryptingStreamer(self.config.master_key,
                                     delimited=True) as es:
                 es.write(data)
                 es.finish()
                 return es.save(None)
+
+        elif tokeys:
+            stat, edata = GnuPG(self.config, event=GetThreadEvent()
+                                ).encrypt(data, tokeys=tokeys)
+            if stat == 0:
+                return edata
 
         return data
 


### PR DESCRIPTION
This PR does two things:

   1. Brings back the ability to load a PGP-encrypted metadata index
   2. Disables generation of (new) PGP-encrypted metadata unless we have no master secret

  