### PR TITLE
Improve keybindings view style

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -6668,6 +6668,23 @@ ul.items li.grouped h5 {
   top: 42px;
   left: 47px;
 }
+/* Keyboard shortcuts */
+kbd {
+  display: inline-block;
+  padding: 5px 8px;
+  margin: 3px;
+  min-width: 10px;
+  border: 1px #b3b3b3 solid;
+  border-bottom: 2px #b3b3b3 solid;
+  border-radius: 3px;
+  background-color: #e9e9e9;
+  font-size: 14px;
+  text-align: center;
+  font-style: normal;
+}
+kbd::first-letter {
+  text-transform: capitalize;
+}
 /* Some general helper classes */
 /*
   Sets cursor to pointer on a tags

--- a/shared-data/default-theme/html/jsapi/templates/modal-display-keybindings.html
+++ b/shared-data/default-theme/html/jsapi/templates/modal-display-keybindings.html
@@ -7,14 +7,22 @@
     <div class="modal-body modal-body-light-gray">
       <table class="default-table">
         <thead>
-          <th>Title</th>
           <th>Binding</th>
+          <th>Title</th>
         </thead>
         <tbody>
           <% _.each(keybindings, function(binding) { if (binding.title) { %>
             <tr>
+              <td>
+                  <% _.each(binding.keys.split(' '), function(keystroke) { %>
+                    <% var keys = keystroke.split('+') %>
+                    <% _.forEach(keys, function(key, idx) { %>
+                      <kbd><%= key %></kbd>
+                      <%= (idx < (keys.length - 1)) ? '+' : '' %>
+                    <% }); %>
+                  <% }); %>
+              </td>
               <td><%= binding.title %></td>
-              <td><%= binding.keys %></td>
             </tr>
           <% } }); %>
         </tbody>

--- a/shared-data/default-theme/less/app/global.less
+++ b/shared-data/default-theme/less/app/global.less
@@ -469,3 +469,23 @@
     top: 42px;
     left: 47px;
   }
+
+/* Keyboard shortcuts */
+
+  kbd {
+     display: inline-block;
+     padding: 5px 8px;
+     margin: 3px;
+     min-width: 10px;
+     border: 1px @gray solid;
+     border-bottom: 2px @gray solid;
+     border-radius: @base-border-radius;
+     background-color: @grayLight;
+     font-size: 14px;
+     text-align: center;
+     font-style: normal;
+  }
+
+  kbd::first-letter {
+      text-transform: capitalize;
+  }


### PR DESCRIPTION
- Make the keys from bindings looking similar to physical ones;
- invert title/binding columns.

Open to suggestions/remarks :-)

Disclaimer: I'm a begginer with *less*.

Before:

![screenshot-localhost 33411 2017-03-30 14-40-34](https://cloud.githubusercontent.com/assets/429633/24504488/c8ee73c6-1556-11e7-8e8c-e02080037864.png)

After:

![screenshot-localhost 33411 2017-03-30 14-38-49](https://cloud.githubusercontent.com/assets/429633/24504496/d0d6c3a4-1556-11e7-986d-4873747e35b3.png)
