### PR TITLE
Implement `onbeforeunload`-event handler for attachment uploads #1811

### DIFF
--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -1,4 +1,13 @@
-/* Compose - Attachments */
+// Compose - Attachments
+window.addEventListener("beforeunload", function (event) {
+  if (Mailpile.Composer.Attachments.Uploader.hasPendingUploads()) {
+    var confirmationMessage = "There is still an attachment upload in progress. Are you sure you want to cancel the upload?";
+    event.returnValue = confirmationMessage;     // Gecko, Trident, Chrome 34+
+    return confirmationMessage;                  // Gecko, WebKit, Chrome <34
+  } else {
+    return true;
+  }
+});
 
 Mailpile.Composer.Attachments.UploaderImagePreview = function(attachment, file) {
 
@@ -90,7 +99,7 @@ Mailpile.Composer.Attachments.UpdatePreviews = function(attachments, mid, file) 
       else {
         var attachment_template = Mailpile.safe_template($('#template-composer-attachment').html());
         var attachment_html = attachment_template(attachment);
-      	$('#compose-attachments-files-' + mid).append(attachment_html);
+        $('#compose-attachments-files-' + mid).append(attachment_html);
       }
     } else {
       console.log('attachment exists ' + attachment.aid);
@@ -98,92 +107,95 @@ Mailpile.Composer.Attachments.UpdatePreviews = function(attachments, mid, file) 
   });
 };
 
-
-Mailpile.Composer.Attachments.Uploader = function(settings) {
-
-  var uploader = new plupload.Uploader({
-  	runtimes : 'html5',
-  	browse_button : settings.browse_button, // you can pass in id...
-  	container: settings.container, // ... or DOM Element itself
-    drop_element: settings.container,
-  	url : Mailpile.API.U('/api/0/message/attach/'),
-    multipart : true,
-    multipart_params : {
-      'mid': settings.mid,
-      'csrf': Mailpile.csrf_token
-    },
-    file_data_name : 'file-data',
-  	filters : {
-  		max_file_size : '50mb'
-  	},
-    resize: {
-      width: '3600',
-      height: '3600',
-      crop: true,
-      quaility: 100
-    },
-    views: {
-      list: true,
-      thumbs: true,
-      active: 'thumbs'
-    },
-  	init: {
-      PostInit: function() {
-        $('#compose-attachments-' + settings.mid).find('.compose-attachment-pick').removeClass('hide');
-        $('#compose-attachments-' + settings.mid).find('.attachment-browswer-unsupported').addClass('hide');
-        uploader.refresh();
+Mailpile.Composer.Attachments.Uploader = {
+  instance: false,
+  init: function(settings) {
+    this.instance = new plupload.Uploader({
+      runtimes : 'html5',
+      browse_button : settings.browse_button, // you can pass in id...
+      container: settings.container, // ... or DOM Element itself
+      drop_element: settings.container,
+      url : Mailpile.API.U('/api/0/message/attach/'),
+      multipart : true,
+      multipart_params : {
+        'mid': settings.mid,
+        'csrf': Mailpile.csrf_token
       },
-      FilesAdded: function(up, files) {
+      file_data_name : 'file-data',
+      filters : {
+        max_file_size : '50mb'
+      },
+      resize: {
+        width: '3600',
+        height: '3600',
+        crop: true,
+        quaility: 100
+      },
+      views: {
+        list: true,
+        thumbs: true,
+        active: 'thumbs'
+      },
+      init: {
+        PostInit: function() {
+          $('#compose-attachments-' + settings.mid).find('.compose-attachment-pick').removeClass('hide');
+          $('#compose-attachments-' + settings.mid).find('.attachment-browswer-unsupported').addClass('hide');
+          this.refresh();
+        },
+        FilesAdded: function(up, files) {
+          // Loop through added files
+          plupload.each(files, function(file) {
 
-        // Loop through added files
-      	plupload.each(files, function(file) {
+            // Show warning for ~20MB or larger
+            if ((file.size < 200000000) ||
+                confirm(file.name + ' {{_("is")|escapejs}} ' + plupload.formatSize(file.size) + '.\n' +
+                        '\n' +
+                        '{{_("Some people cannot receive such large e-mails.")|escapejs}}\n' +
+                        '{{_("Send it anyway?")}}'))
+            {
+              this.start();
+            }
+          }.bind(this));
+        },
+        UploadProgress: function(up, file) {
+          $('#' + file.id).find('b').html('<span>' + file.percent + '%</span>');
+          var progressBar = "<progress value="+file.percent+" max='100'></progress> "+file.percent+"%";
+          $('.attachment-progress-bar').html(progressBar);
+          $('#compose-send-'+settings.mid).attr("disabled","disabled");
+        },
+        FileUploaded: function(up, file, response) {
 
-          // Show warning for ~20MB or larger
-          if ((file.size < 200000000) ||
-              confirm(file.name + ' {{_("is")|escapejs}} ' + plupload.formatSize(file.size) + '.\n' +
-                      '\n' +
-                      '{{_("Some people cannot receive such large e-mails.")|escapejs}}\n' +
-                      '{{_("Send it anyway?")}}'))
-          {
-            uploader.start();
+          if (response.status == 200) {
+
+            var response_json = $.parseJSON(response.response);
+            var new_mid = response_json.result.message_ids[0];
+
+            $('.attachment-progress-bar').empty();
+            $('#compose-send-'+settings.mid).removeAttr("disabled");
+            Mailpile.Composer.Attachments.UpdatePreviews(response_json.result.data.messages[new_mid].attachments, settings.mid, file);
+
           } else {
-            start_upload = false;
+            Mailpile.notification({status: 'error', message: '{{_("Attachment upload failed: status")|escapejs}}: ' + response.status });
           }
-      	});
-      },
-      UploadProgress: function(up, file) {
-      	$('#' + file.id).find('b').html('<span>' + file.percent + '%</span>');
-        var progressBar = "<progress value="+file.percent+" max='100'></progress> "+file.percent+"%";
-        $('.attachment-progress-bar').html(progressBar);
-        $('#compose-send-'+settings.mid).attr("disabled","disabled");
-      },
-      FileUploaded: function(up, file, response) {
-
-        if (response.status == 200) {
-
-          var response_json = $.parseJSON(response.response);
-          var new_mid = response_json.result.message_ids[0];
-
-          //console.log(file);
-          $('.attachment-progress-bar').empty();
-          $('#compose-send-'+settings.mid).removeAttr("disabled");
-          Mailpile.Composer.Attachments.UpdatePreviews(response_json.result.data.messages[new_mid].attachments, settings.mid, file);
-
-        } else {
-          Mailpile.notification({status: 'error', message: '{{_("Attachment upload failed: status")|escapejs}}: ' + response.status });
+        },
+        Error: function(up, err) {
+          Mailpile.notification({status: 'error', message: '{{_("Could not upload attachment because")|escapejs}}: ' + err.message });
+          $('#' + err.file.id).find('b').html('Failed ' + err.code);
+          this.refresh();
         }
-      },
-      Error: function(up, err) {
-        Mailpile.notification({status: 'error', message: '{{_("Could not upload attachment because")|escapejs}}: ' + err.message });
-        $('#' + err.file.id).find('b').html('Failed ' + err.code);
-        uploader.refresh();
       }
+    });
+    this.instance.init();
+    return this.instance;
+  },
+  hasPendingUploads: function() {
+    if (this.instance !== false) {
+      return this.instance.total.queued > 0;
+    } else {
+      return false;
     }
-  });
-
-  return uploader.init();
+  }
 };
-
 
 Mailpile.Composer.Attachments.Remove = function(mid, aid) {
   Mailpile.API.message_unattach_post({ mid: mid, att: aid }, function(result) {

--- a/shared-data/default-theme/html/jsapi/compose/init.js
+++ b/shared-data/default-theme/html/jsapi/compose/init.js
@@ -45,7 +45,7 @@ Mailpile.Composer.init = function(mid, strings, addresses) {
   // Initialize Attachments; use setTimeout to isolate faults.
   setTimeout(function() {
     // FIXME: needs to be bound to unique ID that can be destroyed
-    Mailpile.Composer.Attachments.Uploader({
+    Mailpile.Composer.Attachments.Uploader.init({
       browse_button: 'compose-attachment-pick-' + mid,
       container: 'compose-attachments-' + mid,
       mid: mid


### PR DESCRIPTION
Partially adresses #1811 

If a user uploads an attachment and triggers a full-page-refresh we want to notify him about in-progress uploads and the fact that the full-page-refresh (or unloading the document) will cancel the upload.

The `unbeforeunload`-event can prompt the user with either our custom or a generic message (depending on the user agents implementation) wether she either wants to continue with the full-page-refresh or wants to wait for the page to "finish it works".

![](https://fat.gfycat.com/RelievedElasticCrow.gif)