### PR TITLE
Implement `onbeforeunload`-event handler for attachment uploads #1811

### DIFF
--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -99,8 +99,11 @@ Mailpile.Composer.Attachments.UpdatePreviews = function(attachments, mid, file) 
 };
 
 
-Mailpile.Composer.Attachments.Uploader = function(settings) {
+Mailpile.Composer.Attachments.Uploader = {
+  instance: false
+};
 
+Mailpile.Composer.Attachments.Uploader.init = function(settings) {
   var uploader = new plupload.Uploader({
   	runtimes : 'html5',
   	browse_button : settings.browse_button, // you can pass in id...
@@ -181,6 +184,7 @@ Mailpile.Composer.Attachments.Uploader = function(settings) {
     }
   });
 
+  this.instance = uploader;
   return uploader.init();
 };
 

--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -90,7 +90,7 @@ Mailpile.Composer.Attachments.UpdatePreviews = function(attachments, mid, file) 
       else {
         var attachment_template = Mailpile.safe_template($('#template-composer-attachment').html());
         var attachment_html = attachment_template(attachment);
-      	$('#compose-attachments-files-' + mid).append(attachment_html);
+        $('#compose-attachments-files-' + mid).append(attachment_html);
       }
     } else {
       console.log('attachment exists ' + attachment.aid);
@@ -183,7 +183,6 @@ Mailpile.Composer.Attachments.Uploader = function(settings) {
 
   return uploader.init();
 };
-
 
 Mailpile.Composer.Attachments.Remove = function(mid, aid) {
   Mailpile.API.message_unattach_post({ mid: mid, att: aid }, function(result) {

--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -3,7 +3,7 @@
 // Prompts the user if a full-page-refresh happens while uploading attachments.
 window.addEventListener("beforeunload", function (event) {
   if (Mailpile.Composer.Attachments.Uploader.hasPendingUploads()) {
-    var confirmationMessage = "There is still an attachment upload in progress. Are you sure you want to cancel the upload?";
+    var confirmationMessage = '{{_("There is still an attachment upload in progress. Are you sure you want to cancel the upload?")|escapejs}}';
     event.returnValue = confirmationMessage;     // Gecko, Trident, Chrome 34+
     return confirmationMessage;                  // Gecko, WebKit, Chrome <34
   } else {

--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -1,5 +1,16 @@
 /* Compose - Attachments */
 
+// Prompts the user if a full-page-refresh happens while uploading attachments.
+window.addEventListener("beforeunload", function (event) {
+  if (Mailpile.Composer.Attachments.Uploader.hasPendingUploads()) {
+    var confirmationMessage = "There is still an attachment upload in progress. Are you sure you want to cancel the upload?";
+    event.returnValue = confirmationMessage;     // Gecko, Trident, Chrome 34+
+    return confirmationMessage;                  // Gecko, WebKit, Chrome <34
+  } else {
+    return true;
+  }
+});
+
 Mailpile.Composer.Attachments.UploaderImagePreview = function(attachment, file) {
 
   // Create an instance of the mOxie Image object. This
@@ -100,7 +111,14 @@ Mailpile.Composer.Attachments.UpdatePreviews = function(attachments, mid, file) 
 
 
 Mailpile.Composer.Attachments.Uploader = {
-  instance: false
+  instance: false,
+  hasPendingUploads: function() {
+    if (this.instance !== false) {
+      return this.instance.total.queued > 0;
+    } else {
+      return false;
+    }
+  }
 };
 
 Mailpile.Composer.Attachments.Uploader.init = function(settings) {

--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -123,20 +123,20 @@ Mailpile.Composer.Attachments.Uploader = {
 
 Mailpile.Composer.Attachments.Uploader.init = function(settings) {
   var uploader = new plupload.Uploader({
-  	runtimes : 'html5',
-  	browse_button : settings.browse_button, // you can pass in id...
-  	container: settings.container, // ... or DOM Element itself
+    runtimes : 'html5',
+    browse_button : settings.browse_button, // you can pass in id...
+    container: settings.container, // ... or DOM Element itself
     drop_element: settings.container,
-  	url : Mailpile.API.U('/api/0/message/attach/'),
+    url : Mailpile.API.U('/api/0/message/attach/'),
     multipart : true,
     multipart_params : {
       'mid': settings.mid,
       'csrf': Mailpile.csrf_token
     },
     file_data_name : 'file-data',
-  	filters : {
-  		max_file_size : '50mb'
-  	},
+    filters : {
+      max_file_size : '50mb'
+    },
     resize: {
       width: '3600',
       height: '3600',
@@ -148,7 +148,7 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
       thumbs: true,
       active: 'thumbs'
     },
-  	init: {
+    init: {
       PostInit: function() {
         $('#compose-attachments-' + settings.mid).find('.compose-attachment-pick').removeClass('hide');
         $('#compose-attachments-' + settings.mid).find('.attachment-browswer-unsupported').addClass('hide');
@@ -157,7 +157,7 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
       FilesAdded: function(up, files) {
 
         // Loop through added files
-      	plupload.each(files, function(file) {
+        plupload.each(files, function(file) {
 
           // Show warning for ~20MB or larger
           if ((file.size < 200000000) ||
@@ -170,10 +170,10 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
           } else {
             start_upload = false;
           }
-      	});
+        });
       },
       UploadProgress: function(up, file) {
-      	$('#' + file.id).find('b').html('<span>' + file.percent + '%</span>');
+        $('#' + file.id).find('b').html('<span>' + file.percent + '%</span>');
         var progressBar = "<progress value="+file.percent+" max='100'></progress> "+file.percent+"%";
         $('.attachment-progress-bar').html(progressBar);
         $('#compose-send-'+settings.mid).attr("disabled","disabled");

--- a/shared-data/default-theme/html/jsapi/compose/init.js
+++ b/shared-data/default-theme/html/jsapi/compose/init.js
@@ -45,7 +45,7 @@ Mailpile.Composer.init = function(mid, strings, addresses) {
   // Initialize Attachments; use setTimeout to isolate faults.
   setTimeout(function() {
     // FIXME: needs to be bound to unique ID that can be destroyed
-    Mailpile.Composer.Attachments.Uploader({
+    Mailpile.Composer.Attachments.Uploader.init({
       browse_button: 'compose-attachment-pick-' + mid,
       container: 'compose-attachments-' + mid,
       mid: mid


### PR DESCRIPTION
Partially adresses #1811 

If a user uploads an attachment and triggers a full-page-refresh we want to notify him about in-progress uploads and the fact that the full-page-refresh (or unloading the document) will cancel the upload.

The `unbeforeunload`-event can prompt the user with either our custom or a generic message (depending on the user agents implementation) wether she either wants to continue with the full-page-refresh or wants to wait for the page to "finish it works".

![](https://fat.gfycat.com/RelievedElasticCrow.gif)