### PR TITLE
Enable e-mail deletion

### DIFF
--- a/mailpile/config/defaults.py
+++ b/mailpile/config/defaults.py
@@ -119,6 +119,8 @@ CONFIG_RULES = {
         'encrypt_vcards': X(_('Encrypt the contact database'), bool,     True),
         'encrypt_events': X(_('Encrypt the event log'), bool,            True),
         'encrypt_misc':   X(_('Encrypt misc. local data'), bool,         True),
+        'allow_deletion': X(_('Allow permanent deletion of e-mails'),
+                                                                  bool, False),
         'rescan_command':  (_('Command run before rescanning'), str,       ''),
         'default_email':   (_('Default outgoing e-mail address'), 'email', ''),
         'default_route':   (_('Default outgoing mail route'), str, ''),

--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -133,6 +133,7 @@ class ConfigManager(ConfigDict):
         ConfigDict.__init__(self, _rules=rules, _magic=False)
 
         self.workdir = os.path.abspath(workdir or self.DEFAULT_WORKDIR())
+        self.gnupghome = None
         mailpile.vfs.register_alias('/Mailpile', self.workdir)
 
         self.shareddatadir = os.path.abspath(shareddatadir or
@@ -296,6 +297,9 @@ class ConfigManager(ConfigDict):
 
         # Trigger background-loads of everything
         Rescan(session, 'rescan')._idx(wait=False)
+
+        # Record where our GnuPG keys live
+        self.gnupghome = GnuPG(self).gnupghome()
 
         if keep_lockdown:
             self.sys.lockdown = keep_lockdown

--- a/mailpile/crypto/gpgi.py
+++ b/mailpile/crypto/gpgi.py
@@ -551,18 +551,28 @@ class GnuPG:
         self.homedir = path
 
     def version(self):
-        """Returns a tuple representing the GnuPG version number."""
+        """Returns a string representing the GnuPG version number."""
         self.event.running_gpg(_('Checking GnuPG version'))
         retvals = self.run(["--version"], novercheck=True)
         return retvals[1]["stdout"][0].split('\n')[0]
 
     def version_tuple(self, update=False):
+        """Returns a tuple representing the GnuPG version number."""
         global GPG_VERSIONS
         if update or not GPG_VERSIONS.get(self.gpgbinary):
             vertext = self.version().strip().split()[-1]
             version = tuple(int(v) for v in vertext.split('.'))
             GPG_VERSIONS[self.gpgbinary] = version
         return GPG_VERSIONS[self.gpgbinary]
+
+    def gnupghome(self):
+        """Returns the location of the GnuPG keyring"""
+        self.event.running_gpg(_('Checking GnuPG home directory'))
+        rv = self.run(["--version"], novercheck=True)[1]["stdout"][0]
+        for l in rv.splitlines():
+            if l.startswith('Home: '):
+                return os.path.expanduser(l[6:].strip())
+        return os.path.expanduser(os.getenv('GNUPGHOME', '~/.gnupg'))
 
     def is_available(self):
         try:

--- a/mailpile/index/base.py
+++ b/mailpile/index/base.py
@@ -109,7 +109,7 @@ class BaseIndex(MessageInfoConstants):
     ### Loading data: higher level methods #################################
 
     def enumerate_ptrs_mboxes_fds(self, msg_info):
-        for msg_ptr in msg_info[self.MSG_PTRS].split(','):
+        for msg_ptr in self._sorted_msg_ptrs(msg_info):
             msg_ptr = msg_ptr.strip()
             if not msg_ptr:
                 continue
@@ -127,6 +127,13 @@ class BaseIndex(MessageInfoConstants):
 
 
     ### ... ################################################################
+
+    def _sorted_msg_ptrs(self, msg_info):
+        ptrs = [p for p in msg_info[self.MSG_PTRS].split(',') if p]
+        # FIXME: Prefer local data? Prefer some mailbox types? Hmm.
+        #        Doing this well would speed things up and ensure the
+        #        `message/delete --keep` deduplication works nicely.
+        return ptrs
 
     def _encode_msg_id(self, msg_id):
         """Normalize and hash a message ID for the metadata index"""

--- a/mailpile/mailboxes/macmail.py
+++ b/mailpile/mailboxes/macmail.py
@@ -66,9 +66,11 @@ class MacMaildir(mailbox.Mailbox):
 
     def remove(self, key):
         """Remove the message or raise error if nonexistent."""
-        raise NotImplemented("Mailpile is readonly, for now.")
-        # FIXME: Hmm?
-        #safe_remove(os.path.join(self._mailroot, self._lookup(key)))
+        safe_remove(os.path.join(self._mailroot, self._lookup(key)))
+        try:
+            del self._toc[key]
+        except:
+            pass
 
     def discard(self, key):
         """If the message exists, remove it."""

--- a/mailpile/mailboxes/pop3.py
+++ b/mailpile/mailboxes/pop3.py
@@ -137,6 +137,16 @@ class POP3Mailbox(Mailbox):
             ok, info, octets = self._pop3.list(self._km[key]).split()
             return int(octets)
 
+    def remove(self, key):
+        # FIXME: This is very inefficient if we are deleting multiple
+        #        messages at once.
+        with self._lock:
+            self._connect()
+            if key not in self.iterkeys():
+                raise KeyError('Invalid key: %s' % key)
+            ok = self._pop3.dele(self._km[key])
+            self._refresh()
+
     def stat(self):
         with self._lock:
             self._connect()

--- a/mailpile/plugins/__init__.py
+++ b/mailpile/plugins/__init__.py
@@ -68,7 +68,7 @@ class PluginManager(object):
     ]
     # Plugins we want, if they are discovered
     WANTED = [
-        'autoajax', 'print', 'datadig'
+        'autoajax', 'print', 'datadig', 'hints'
     ]
     # Plugins that have been renamed from past releases
     RENAMED = {

--- a/mailpile/plugins/core.py
+++ b/mailpile/plugins/core.py
@@ -345,6 +345,7 @@ class DeleteMessages(Command):
     """Delete one or more messages."""
     SYNOPSIS = (None, 'delete', 'message/delete', '[--keep] <messages>')
     ORDER = ('Searching', 99)
+    IS_USER_ACTIVITY = True
 
     def command(self, slowly=False):
         idx = self._idx()

--- a/mailpile/plugins/core.py
+++ b/mailpile/plugins/core.py
@@ -359,8 +359,9 @@ class DeleteMessages(Command):
                 failed.append(msg_idx)
 
         # This will actually delete from mboxes, etc.
-        for m in mailboxes:
-            m.flush()
+        for m in set(mailboxes):
+            with m:
+                m.flush()
 
         # FIXME: Trigger a background rescan of affected mailboxes, as
         #        the flush() above may have broken our pointers.

--- a/mailpile/plugins/core.py
+++ b/mailpile/plugins/core.py
@@ -343,15 +343,23 @@ class Optimize(Command):
 
 class DeleteMessages(Command):
     """Delete one or more messages."""
-    SYNOPSIS = (None, 'delete', 'message/delete', '<messages>')
+    SYNOPSIS = (None, 'delete', 'message/delete', '[--keep] <messages>')
     ORDER = ('Searching', 99)
 
     def command(self, slowly=False):
         idx = self._idx()
+
+        args = list(self.args)
+        keep = 0
+        while '--keep' in args:
+            args.remove('--keep')
+            keep += 1
+
         deleted, failed, mailboxes = [], [], []
-        for msg_idx in self._choose_messages(self.args):
+        for msg_idx in self._choose_messages(args):
             e = Email(idx, msg_idx)
-            del_ok, mboxes = e.delete_message(self.session, flush=False)
+            del_ok, mboxes = e.delete_message(self.session,
+                                              flush=False, keep=keep)
             mailboxes.extend(mboxes)
             if del_ok:
                 deleted.append(msg_idx)

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -132,6 +132,8 @@ class SetupMagic(Command):
             'display_order': 6,
             'icon': 'icon-trash',
             'label_color': '13-brown',
+            'auto_after': 91,
+            'auto_action': '!delete',
             'name': _('Trash'),
         },
         # These are magical tags that perform searches and show

--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -435,6 +435,7 @@ class MailIndex(BaseIndex):
         existing_ptrs = set()
         messages = sorted(mbox.keys())
         messages_md5 = md5_hex(str(messages))
+        mbox_version = mbox.last_updated()
         if messages_md5 == self._scanned.get(mailbox_idx, ''):
             return finito(0, _('%s: No new mail in: %s'
                                ) % (mailbox_idx, mailbox_fn),
@@ -477,6 +478,9 @@ class MailIndex(BaseIndex):
                 messages_md5 = not_done_yet
                 break
             elif deadline and time.time() > start_time + deadline:
+                messages_md5 = not_done_yet
+                break
+            elif mbox_version != mbox.last_updated():
                 messages_md5 = not_done_yet
                 break
 

--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -345,19 +345,13 @@ class MailIndex(BaseIndex):
 
         msg_info = self.get_msg_at_idx_pos(msg_idx_pos)
         msg_ptrs = msg_info[self.MSG_PTRS].split(',')
-        self.PTRS[msg_ptr] = msg_idx_pos
 
-        # If message was seen in this mailbox before, update the location
-        for i in range(0, len(msg_ptrs)):
-            if msg_ptrs[i][:MBX_ID_LEN] == msg_ptr[:MBX_ID_LEN]:
-                msg_ptrs[i] = msg_ptr
-                msg_ptr = None
-                break
-        # Otherwise, this is a new mailbox, record this sighting as well!
+        # New location! Some other process will prune obsolete pointers.
         if msg_ptr:
+            self.PTRS[msg_ptr] = msg_idx_pos
             msg_ptrs.append(msg_ptr)
 
-        msg_info[self.MSG_PTRS] = ','.join(msg_ptrs)
+        msg_info[self.MSG_PTRS] = ','.join(list(set(msg_ptrs)))
         self.set_msg_at_idx_pos(msg_idx_pos, msg_info)
         return msg_info
 
@@ -1379,6 +1373,9 @@ class MailIndex(BaseIndex):
         for tag in self.get_tags(msg_info=info):
             self.remove_tag(session, tag, msg_idxs=[msg_idx])
 
+        # Record that these messages were deleted
+        GlobalPostingList.Append(session, 'deleted:is', [b36(msg_idx)])
+
     def update_msg_sorting(self, msg_idx, msg_info):
         for order, sorter in self.SORT_ORDERS.iteritems():
             self.INDEX_SORT[order][msg_idx] = sorter(self, msg_info)
@@ -1608,8 +1605,14 @@ class MailIndex(BaseIndex):
                     return self.TAGS.get(term.rsplit(':', 1)[0], [])
                 else:
                     session.ui.mark(_('Searching for %s') % term)
-                    return [int(h, 36) for h
-                            in GlobalPostingList(session, term).hits()]
+                    gpl_hits = GlobalPostingList(session, term).hits()
+                    try:
+                        return [int(h, 36) for h in gpl_hits]
+                    except ValueError:
+                        b36re = re.compile('^[a-zA-Z0-9]{1,8}$')
+                        print 'FIXME! BAD HITS: %s => %s' % (term, [
+                            h for h in gpl_hits if not b36re.match(h)])
+                        return [int(h, 36) for h in gpl_hits if b36re.match(h)]
 
         # Replace some GMail-compatible terms with what we really use
         if 'tags' in self.config:
@@ -1635,6 +1638,7 @@ class MailIndex(BaseIndex):
 
         searched_invisible = False
         searched_mailbox = False
+        searched_deleted = False
 
         for term in searchterms:
             if term in STOPLIST:
@@ -1694,6 +1698,8 @@ class MailIndex(BaseIndex):
                             session, 'in:mp_sig-%s' % status, hits,
                             recursion=recursion)[0])
                 else:
+                    if term == 'is:deleted':
+                        searched_deleted = True
                     t = term.split(':', 1)
                     fnc = _plugins.get_search_term(t[0])
                     if fnc:
@@ -1725,10 +1731,12 @@ class MailIndex(BaseIndex):
         if (results and (keywords is None) and
                 (not searched_invisible) and
                 (not searched_mailbox) and
+                (not searched_deleted) and
                 ('tags' in self.config) and
                 (not session or 'all' not in order)):
             invisible = self.config.get_tags(flag_hides=True)
-            exclude_terms = ['in:%s' % i._key for i in invisible]
+            exclude_terms = (['is:deleted'] +
+                             ['in:%s' % i._key for i in invisible])
             if len(exclude_terms) > 1:
                 exclude_terms = ([exclude_terms[0]] +
                                  ['+%s' % e for e in exclude_terms[1:]])

--- a/shared-data/contrib/autoajax/autoajax.js
+++ b/shared-data/contrib/autoajax/autoajax.js
@@ -154,6 +154,7 @@ prepare_new_content = function(selector) {
         if (url &&
                 (url.indexOf('#') != 0) &&
                 (url.indexOf('mailto:') != 0) &&
+                (url.indexOf('javascript:') != 0) &&
                 (elem.target != '_blank') &&
                 (elem.className.indexOf('auto-modal') == -1)) {
             $(elem).click(function(ev) {

--- a/shared-data/contrib/hints/hints.html
+++ b/shared-data/contrib/hints/hints.html
@@ -1,0 +1,51 @@
+{% extends "logs/layout.html" %}
+{% block content %}
+<div class="content-normal" style="max-width: 46em;">
+
+  <h1><span class="icon-lightbulb"></span> {{message}}</h1>
+  <br>
+
+  <p>
+    {{_("Mailpile will by default give hints now and then to help you get more out of the application.")}}
+    {{_("Here you can see a list of all the hints and when they are scheduled for display.")}}
+    {{_("Clicking on a hint will display more information.")}}
+  </p>
+  <table><tbody>
+    <tr>
+      <th>{{_("Days")}}</th><th>{{_("Hint")}}</th><th></th>
+    </tr>
+  {% for hint in result.hints %}
+    <tr>
+      <td>
+        {%- if hint.in_days < 1 %}
+          due
+        {%- else %}
+          {{- hint.in_days }}
+        {%- endif %}
+      </td>
+      <td><a class="{{ hint.action_cls }}" {% if hint.action_js -%}
+        {{ hint.action_js|safe -}}
+      {% else -%}
+        href="{{ U(hint.action_url) }}"
+      {%- endif %}>
+        {%- if not hint.applies %}<del>{% endif %}
+          {{ hint.message2 }}
+        {%- if not hint.applies %}</del>{% endif %}
+      </td>
+      <td>
+        {%- if not hint.applies %}
+          <span class="icon icon-x color-01-gray-mid"></span>
+        {%- elif hint.displayed %}
+          <span class="icon icon-checkmark color-08-green"></span>
+        {%- endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody></table><br>
+
+  <p>
+    {{_("Note: Some hints are context sensitive and may no longer apply; those hints are still listed, but crossed out.")}}
+  </p>
+
+</div>
+{% endblock %}

--- a/shared-data/contrib/hints/hints.js
+++ b/shared-data/contrib/hints/hints.js
@@ -1,0 +1,36 @@
+/* Mailpile.plugins.hints */
+
+$(document).ready(function() {
+  // Display initial hint randomly 1 to 5 minutes after page load
+  setTimeout(Mailpile.plugins.hints.hint, (1 + 4 * Math.random()) * 60000);
+});
+
+return {
+  hint: function() {
+    // Check for new hints every 3.5 - 4.5 hours
+    setTimeout(Mailpile.plugins.hints.hint, (3.5 + Math.random()) * 3600000);
+
+    // Using the POST method will record the hint as having been displayed.
+    // FIXME: Should we use GET, and then POST if the user interacts?
+    Mailpile.API.logs_hints_post({
+      now: true,
+    }, function(response) {
+      if (response.result.hints.length) {
+        var hint = response.result.hints[0];
+        hint['status'] = 'info';
+        hint['icon'] = 'icon-lightbulb';
+        if (hint['action_url'].indexOf('javascript:') != 0) {
+          hint['action_url'] = Mailpile.API.U(hint['action_url']);
+        }
+        Mailpile.notification(hint);
+      }
+    });
+  },
+  release_notes: function(ev) {
+    $('#release_notes').eq(0).trigger('click');
+  },
+  keybindings: function() {
+    Mailpile.display_keybindings();
+  },
+};
+

--- a/shared-data/contrib/hints/hints.py
+++ b/shared-data/contrib/hints/hints.py
@@ -1,0 +1,162 @@
+# This is our very own Clippy replacement...
+
+import time
+
+from gettext import gettext
+from mailpile.plugins import PluginManager
+
+_ = lambda t: t
+
+
+##[ Pluggable commands and data views ]#######################################
+
+import random
+from mailpile.config.defaults import APPVER
+from mailpile.commands import Command
+from mailpile.util import md5_hex
+
+
+TIMESTAMPS = None
+
+
+class hintsCommand(Command):
+    """Provide periodic hints to the user"""
+    SYNOPSIS_ARGS = '[now|reset]'
+    SPLIT_ARG = True
+    HTTP_CALLABLE = ('GET', 'POST')
+    HTTP_QUERY_VARS = {
+       'now': 'Request a single due hint',
+       'context': 'Current UI context'
+    }
+
+    ALL_HINTS = [
+        # ID, Min age (in days), Interval, Short hint, Details, [Precondition]
+        (APPVER, 0, 99999,
+            _('This is Mailpile version %s') % APPVER,
+            # Note: The style of quotes matters here, because the JS sucks
+            #       a bit. Single quotes only please!
+            "javascript:Mailpile.plugins.hints.release_notes();"),
+        ('deletion', 3, 30,
+            _('Your Mailpile is configured to never delete e-mail'),
+            '/page/hints/deletion.html',
+            lambda cfg, ctx: not cfg.prefs.allow_deletion),
+        ('keyboard', 5, 30,
+            _('Mailpile has keyboard short-cuts!'),
+            "javascript:Mailpile.plugins.hints.keybindings();"),
+        ('backups', 7, 6,
+            _('You really should make backups of your Mailpile'),
+            '/page/hints/backups.html')]
+        # FIXME: Say something about the spam filter
+        # FIXME: Say something about autotagging
+
+    def _today(self):
+        return int(time.time() // (24*3600))
+
+    def timestamps(self):
+        global TIMESTAMPS
+        if TIMESTAMPS is None:
+            try:
+                TIMESTAMPS = self.session.config.load_pickle('hints.dat')
+            except:
+                TIMESTAMPS = {'initial': self._today()}
+                self.save_timestamps()
+        return TIMESTAMPS
+
+    def save_timestamps(self):
+        global TIMESTAMPS
+        if TIMESTAMPS:
+            self.session.config.save_pickle(TIMESTAMPS, 'hints.dat')
+
+    def _days(self):
+        return int(self._today() - self.timestamps()['initial'])
+
+    def _hint_days(self, hint):
+        # This will allow the user to postpone a hint; we check the timestamp
+        # data file before falling back to the hardcoded default.
+        return int(self.timestamps().get('days:%s' % hint[0], hint[1]))
+
+    def _postpone_hint(self, hint, days=None):
+        ts = self.timestamps()
+        ts['days:%s' % hint[0]] = int(self._days() + (days or hint[2]))
+        ts['last_displayed'] = self._today()
+        self.save_timestamps()
+
+    def _hint_applies(self, hint, ctx):
+        if len(hint) > 5:
+            return hint[5](self.session.config, ctx)
+        else:
+            return True
+
+    def _hint_event(self, ctx, hint):
+        applies = self._hint_applies(hint, ctx)
+
+        in_days = max(0, self._hint_days(hint) - self._days())
+        if in_days > 9999:
+            in_days = _('never')
+
+        action_url, action_cls = hint[4], ''
+        if action_url.startswith('/page/'):
+            action_cls = 'auto-modal'
+
+        return {
+            'action_cls': action_cls,
+            'action_url': action_url,
+            'action_text': _('learn more') if hint[3] else '',
+            'applies': applies,
+            'message': _('Did you know') + ' ...',
+            'message2': _(hint[3]),
+            'in_days': in_days,
+            'interval': hint[2],
+            'data': {},
+            'name': hint[0]}
+
+    def _choose_hint(self, ctx):
+        if self._today() == self.timestamps().get('last_displayed'):
+            return None
+
+        days = self._days()
+        hints = [(self._hint_days(h) - days, h)
+                 for h in self.ALL_HINTS if self._hint_applies(h, ctx)]
+
+        if hints:
+            oldest = min(hints)
+            if oldest[0] <= 0:
+                return oldest[1]
+
+        return None
+
+    def command(self):
+        ctx = self.data.get('context')
+
+        if 'reset' in self.args:
+            assert(self.data.get('_method', 'POST') == 'POST')
+            ts = self.timestamps()
+            for k in ts.keys():
+                del ts[k]
+            ts['initial'] = self._today()
+
+        elif 'next' in self.args:
+            assert(self.data.get('_method', 'POST') == 'POST')
+            self.timestamps()['last_displayed'] = 0
+            self.timestamps()['initial'] -= 30
+
+        if 'now' in self.args or 'now' in self.data:
+            hint = self._choose_hint(ctx)
+            if hint:
+                if 'POST' == self.data.get('_method', 'POST'):
+                    self._postpone_hint(hint)
+                return self._success(hint[3], result={
+                    'hints': [self._hint_event(ctx, hint)]})
+            else:
+                return self._success(_('Nothing Happened'), result={
+                    'hints': []})
+        else:
+            return self._success(_('Did you know') + ' ...', result={
+                'today': self._today(),
+                'days': self._days(),
+                'ts': self.timestamps(),
+                'hints': [self._hint_event(ctx, h) for h in self.ALL_HINTS]})
+
+
+_ = gettext
+# EOF #

--- a/shared-data/contrib/hints/hints/backups.html
+++ b/shared-data/contrib/hints/hints/backups.html
@@ -1,0 +1,37 @@
+{% extends "layouts/" + render_mode + "-tall.html" %}
+{% block title %}{{_("Backup Reminder")}}{% endblock %}
+{% block content %}
+<div class="content-normal" style="max-width: 46em;">
+
+  <h1><span class="icon-archive"></span>
+    {{_("Backup Reminder")}}
+  </h1>
+  <p>
+    {{_("Your Mailpile now has {t} tags and {e} e-mails.")
+        .format(t=(config.tags|length - 36), e=mailpile_size)}}
+  </p>
+  <ul class="list" style="margin-left: 2em; list-style: disc">
+    <li>{{_("There is no password reset function.")}}</li>
+    <li>{{_("If your encryption keys are lost, e-mail may become permanently inaccessible.")}}</li>
+{% if config.prefs.allow_deletion %}
+    <li><a class="auto-modal" href="/page/hints/deletion.html">{{_("E-mail deletion is enabled.")}}</a></li>
+{% endif %}
+  </ul>
+
+  <p>
+    {{_("Please make sure you have good backups!")}}
+    <br>
+    {{_("Your Mailpile data is in these locations:")}}
+  </p>
+  <ul class="list" style="margin-left: 2em; list-style: disc">
+    <li><a href="file://{{ config.workdir }}">{{ config.workdir }}</a>
+{%- if config.gnupghome != config.workdir %} ({{_("Mailpile data")}})</li>
+    <li><a href="file://{{ config.gnupghome }}">{{ config.gnupghome }}</a> ({{_("PGP keys")}})
+{%- endif %}</li>
+  </ul>
+  <p>
+    {{_("It is also a good idea to write down your Mailpile password, if you think there is any chance you might forget it.")}}</li>
+  </p>
+
+</div>
+{% endblock %}

--- a/shared-data/contrib/hints/hints/deletion.html
+++ b/shared-data/contrib/hints/hints/deletion.html
@@ -1,0 +1,37 @@
+{% extends "layouts/" + render_mode + "-tall.html" %}
+{% block title %}{{_("E-mail Deletion")}}{% endblock %}
+{% block content %}
+<div class="content-normal" style="max-width: 46em;">
+
+  <h1><span class="icon-trash"></span>
+    {{_("E-Mail Deletion")}}
+  </h1>
+{% if config.prefs.allow_deletion %}
+  <p>
+    {{_("Your Mailpile is configured to allow permanent deletion of e-mail.")}}
+  </p>
+  <ul class="list" style="margin-left: 2em; list-style: disc">
+    <li>{{_("Depending on your preferences, messages may be permanently deleted from remote IMAP or POP3 servers after they have been downloaded.")}}</li>
+    <li>{{_("When e-mail expires from the Trash (or you empty the trash manually), the messages will be gone forever unless you have kept backups.")}}</li>
+  </ul>
+  <p>
+    {{_("This is good for your privacy and may also conserve some disk space.")}}
+  </p>
+{% else %}
+  <p>
+    {{_("Deletion of e-mail is currently disabled.")}}
+  </p>
+  <ul class="list" style="margin-left: 2em; list-style: disc">
+    <li>{{_("Original copies of all e-mail will be left intact on any IMAP or POP3 servers.")}}</li>
+    <li>{{_("The Trash cannot be emptied.")}}</li>
+  </ul>
+  <p>
+    {{_("This is fine if you are just testing Mailpile.")}}
+  </p>
+{% endif %}
+  <p><a href="/settings/privacy.html#data-security">
+    {{_("Click here to change your e-mail deletion settings.")}}
+  </a></p>
+
+</div>
+{% endblock %}

--- a/shared-data/contrib/hints/manifest.json
+++ b/shared-data/contrib/hints/manifest.json
@@ -1,0 +1,34 @@
+# This is a Mailpile plugin manifest, describing the `hints` plugin.
+#
+{
+    "name": "hints",
+    "author": "The Mailpile Team <team@mailpile.is>",
+    "code": {
+        "python": ["hints.py"],
+        "javascript": ["hints.js"]
+    },
+    "routes": {
+        "/logs/hints/": {"file": "hints.html"},
+        "/page/hints/deletion.html": {"file": "hints/deletion.html"},
+        "/page/hints/backups.html": {"file": "hints/backups.html"}
+    },
+    "user_interface": {
+        "activities": [
+            {
+                "context": ["/logs/events/", "/logs/network/", "/logs/hints/"],
+                "name": "hints",
+                "text": "Hints",
+                "icon": "lightbulb",
+                "description": "Tips and tricks",
+                "url": "/logs/hints/"
+            }
+        ]
+    },
+    "commands": [
+        {
+            "class": "hintsCommand",
+            "url": "logs/hints",
+            "name": "hints"
+        }
+    ]
+}

--- a/shared-data/default-theme/html/jsapi/ui/events.js
+++ b/shared-data/default-theme/html/jsapi/ui/events.js
@@ -88,6 +88,9 @@ Mailpile.auto_modal = function(params) {
           header: params.header,
           flags: params.flags
         }));
+        if (!params.title) {
+          mf.find('.modal-title').html(mf.find('h1').html());
+        }
         if (params.reload && !params.callback) {
           params.callback = function(data) { location.reload(true); };
         }

--- a/shared-data/default-theme/html/jsapi/ui/notifications.js
+++ b/shared-data/default-theme/html/jsapi/ui/notifications.js
@@ -53,7 +53,7 @@ Mailpile.notification = function(result) {
   if (result.event_id !== undefined) {
     result.event_id = result.event_id.split('.').join('-');
   } else {
-    result.event_id = 'fake-id-' + Math.random().toString(24).substring(2);
+    result.event_id = 'fake-id-' + Math.random().toString(24).substring(5);
   }
 
   // Message
@@ -84,6 +84,7 @@ Mailpile.notification = function(result) {
   if (result.action      === undefined) result.action = '';
   if (result.action_js   === undefined) result.action_js = '';
   if (result.action_url  === undefined) result.action_url = '';
+  if (result.action_cls  === undefined) result.action_cls = '';
   if (result.action_text === undefined) result.action_text = '';
   if (result.icon        === undefined) result.icon = 'icon-inbox';
   if (result.timeout     === undefined) {

--- a/shared-data/default-theme/html/layouts/content.html
+++ b/shared-data/default-theme/html/layouts/content.html
@@ -43,19 +43,19 @@
         </b><br></noscript>
         <a href="{{ U("/page/release-notes/license.html") }}"
            title="{{_("The AGPLv3 License")}}"
-           >{{_("Copyright")}} 2013-2017</a>,
+           id="copyright">{{_("Copyright")}} 2013-2017</a>,
         <a href="https://www.mailpile.is/" target=_blank
            title="{{_("Visit www.mailpile.is")}}"
-           >Mailpile ehf</a> &amp;
+           id="mailpile_ehf">Mailpile ehf</a> &amp;
         <a href="{{ U("/page/release-notes/credits.html") }}" class="auto-modal"
            title="{{_("Credits and Thanks")}}"
-           >{{_("the community")}}</a> &dash;
+           id="credits">{{_("the community")}}</a> &dash;
         <a href="{{ U("/page/release-notes/") }}" class="auto-modal"
            title="{{_("Welcome to Mailpile %(version)s", version=config.version)}}"
-           >{{_("About")}}</a>&dash;
+           id="release_notes">{{_("About")}}</a>&dash;
         <a href="{{ U("/settings/privacy.html") }}"
            title="{{_("Security and Privacy Settings")}}"
-           >{{_("Privacy")}}</a>
+           id="privacy_settings">{{_("Privacy")}}</a>
       </div>
 {%- endblock %}
     </div>

--- a/shared-data/default-theme/html/partials/hidden.html
+++ b/shared-data/default-theme/html/partials/hidden.html
@@ -243,15 +243,15 @@
       <% if (message2) { %>
       <span class="action"><%= message2 %>
       <%   if (action_js) { %>
-        - <a <%= action_js %> data-event_id="<%= event_id %>" class="action"><%= action_text %></a>
+        - <a <%= action_js %> data-event_id="<%= event_id %>" class="action <%= action_cls %>"><%= action_text %></a>
       <%   } else if (action_url) { %>
-        - <a href="<%= action_url %>" data-event_id="<%= event_id %>" class="action"><%= action_text %></a>
+        - <a href="<%= action_url %>" data-event_id="<%= event_id %>" class="action <%= action_cls %>"><%= action_text %></a>
       <%   } %>
       </span>
       <% } else if (type === 'nagify') { %>
-      <span class="action">{{"Want to"}} <a href="<%= action %>" data-event_id="<%= event_id %>" class="action notification-nag">{{_("do it now?")}}</a></span>
+      <span class="action">{{"Want to"}} <a href="<%= action %>" data-event_id="<%= event_id %>" class="action notification-nag <%= action_cls %>">{{_("do it now?")}}</a></span>
       <% } else if (undo) { %>
-      <span class="action">{{_("A mistake?")}} <a href="#" data-event_id="<%= event_id %>" class="action notification-undo">{{_("undo")}}</a></span>
+      <span class="action">{{_("A mistake?")}} <a href="#" data-event_id="<%= event_id %>" class="action notification-undo <%= action_cls %>">{{_("undo")}}</a></span>
       <% } %>
     </span>
     <a href="#" data-type="<%= type %>" class="notification-close"><span class="icon-x"></span></a>

--- a/shared-data/default-theme/html/profiles/account-form.html
+++ b/shared-data/default-theme/html/profiles/account-form.html
@@ -485,16 +485,11 @@
                    placeholder="{{_('sssh!')}}">
           </div>
           <div class="left" style="margin-right: 0; width: 29em;">
-{%- if is_dev_version() %}
             <input type="checkbox" name="source-{{ new_rid }}-leave-on-server" value="yes"
                    {% if result['source-' + rid + '-leave-on-server'] %}checked{% endif %}>
             <span class="checkbox">
               {{_("Leave mail on server")}}
             </span><br>
-{%- else %}
-            <input type="hidden" name="source-{{ new_rid }}-leave-on-server"
-                   value="yes">
-{%- endif %}
 
             <input type="checkbox" name="source-{{ new_rid }}-index-all-mail" value="yes"
                    {% if result['source-' + rid + '-index-all-mail'] %}checked{% endif %}>

--- a/shared-data/default-theme/html/settings/privacy.html
+++ b/shared-data/default-theme/html/settings/privacy.html
@@ -40,7 +40,7 @@
     {% endif %}
   </div>
 
-  <div class="setting-group">
+  <a name="network"></a><div class="setting-group">
     <h3>{{_("Networking Privacy")}}</h3>
     <div class="explanation">
       <p class="what">
@@ -171,7 +171,7 @@
     <br clear="both">
   </div>
 
-  <div class="setting-group">
+  <a name="motd"></a><div class="setting-group">
     <h3>{{_("Message Of The Day")}}</h3>
     <div class="explanation">
       <p class="what">
@@ -232,7 +232,7 @@
     <br clear="both">
   </div>
 
-  <div class="setting-group">
+  <a name="third-party-content"></a><div class="setting-group">
     <h3>{{_("Third Party Content")}}</h3>
     <div class="explanation">
       <p class="what">
@@ -285,8 +285,8 @@
     <br clear="both">
   </div>
 
-  <div class="setting-group">
-    <h3>{{_("Encrypting Your Data")}}</h3>
+  <a name="data-security"></a><div class="setting-group">
+    <h3>{{_("Securing Your Data")}}</h3>
     <div class="explanation">
       <p class="what">
         <span class="icon icon-lock-closed"></span>
@@ -306,6 +306,15 @@
       </p>
     </div>
     <div class="settings">
+
+      <input name="prefs.allow_deletion" type="radio" value="true"
+            {%- if config.prefs.allow_deletion %} checked{% endif %}>
+      <span class="checkbox">{{_("On")}}</span>
+      <input name="prefs.allow_deletion" type="radio" value="false"
+             {%- if not config.prefs.allow_deletion %} checked{% endif %}>
+      <span class="checkbox">{{_("Off")}}</span> &nbsp; - &nbsp;
+      {{_("Allow deletion of e-mail from servers and mailboxes")}}
+      <br>
 
       <input name="prefs.encrypt_mail" type="radio" value="true"
             {%- if config.prefs.encrypt_mail %} checked{% endif %}>
@@ -357,12 +366,13 @@
       <input name="prefs.encrypt_index" type="radio" value="false"
              {%- if not config.prefs.encrypt_index %} checked{% endif %}>
       <span class="checkbox">{{_("Off")}}</span> &nbsp; - &nbsp;
-      {{_("Strongly encrypt the local search index (slow).")}}<br>
+      {{_("Strongly encrypt the local search index (slow).")}}
+      <br>
 
       <br>
       <b>{{_("Notes:")}}</b>
       <ul class="notes">
-        <li>{{_("Changing these settings will only affect data created or edited from now on.")}}</li>
+        <li>{{_("Changing encryption settings will only affect data created or edited from now on.")}}</li>
         <li>{{_("The search index is always at least partially encrypted because it is so sensitive.")}}</li>
         <li>{{_("The configuration is always kept encrypted, because it may contain passwords.")}}</li>
       </ul>

--- a/shared-data/default-theme/html/tags/form.html
+++ b/shared-data/default-theme/html/tags/form.html
@@ -258,6 +258,9 @@
           <option value="{{ to_inbox }}" {% if tag.auto_action == to_inbox %}selected{% endif %}>{{ _("Move to Inbox") }}</option>
 {%-   endif %}
           <option value="{{ to_trash }}" {% if tag.auto_action == to_trash %}selected{% endif %}>{{ _("Move to Trash") }}</option>
+{%-   if config.prefs.allow_deletion or tag.auto_action == '!delete' %}
+          <option value="!delete" {% if tag.auto_action == "!delete" %}selected{% endif %}>{{ _("Delete e-mails") }}</option>
+{%-   endif %}
 {%-   if tag.auto_action not in ("", "!untag", "!delete", to_after, to_trash) %}
           <option value="{{ tag.auto_action }}" selected>{{ tag.auto_action }}</option>
 {%-   endif %}


### PR DESCRIPTION
This is a big, scary PR which does two important things:

1. Enable actual deletion of e-mails, both locally and from remote servers
2. Add a "hints" mechanism which lets us explain aspects of the app via. notifications that show up after the user has been using Mailpile for a while.

These are together, because I don't want to ship 1. without 2. - this first hints talk about deletion and backups.

I've done my best to break all the scary bits of 1. into bite-sized individual commits to facilitate review.