### PR TITLE
Fix travis build (make the mailpile-test.py non-interactive again)

### DIFF
--- a/scripts/mailpile-test.py
+++ b/scripts/mailpile-test.py
@@ -76,6 +76,8 @@ def say(stuff):
 
 
 def do_setup():
+    # Set it first to avoid interactive prompt for a passphrase
+    config.passphrases['DEFAULT'].set_passphrase('mailpile')
     # Set up initial tags and such
     mp.setup()
     mp.profiles_add(MY_FROM, '=', MY_NAME)


### PR DESCRIPTION
It was waiting on a password prompt. stalling the CI run : "No output has been
received in the last 10m0s, this potentially indicates a stalled build or
something wrong with the build itself."