### PR TITLE
fixed layout for pile table  (removes horizontal scroll)

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -8380,7 +8380,7 @@ tr.modal-tag-picker-item td.checkbox {
   }
 }
 #pile-results td.date {
-  width: 60px;
+  width: 80px;
   text-align: right;
   white-space: nowrap;
   color: #b3b3b3;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -8237,8 +8237,7 @@ tr.modal-tag-picker-item td.checkbox {
   cursor: move;
 }
 #pile-results td.crypto-and-tags,
-#pile-results td.message-nav,
-#pile-results td.avatar {
+#pile-results td.message-nav {
   width: 24px;
   text-align: center;
   white-space: nowrap;
@@ -8259,6 +8258,18 @@ tr.modal-tag-picker-item td.checkbox {
 #pile-results.snug td.avatar {
   padding-top: 4px;
   padding-bottom: 3px;
+}
+#pile-results.comfy td.avatar {
+  width: 32px;
+  padding-right: 8px;
+}
+#pile-results.cozy td.avatar {
+  width: 24px;
+  padding-right: 6px;
+}
+#pile-results.snug td.avatar {
+  width: 18px;
+  padding-right: 4px;
 }
 #pile-results.comfy td.avatar a img {
   width: 24px;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -7,15 +7,15 @@
 ================================================== */
 /* @license
  * Mailpile font designed for Mailpile
- * 
+ *
  * You may obtain a copy of the license at the URLs below.
- * 
+ *
  * Webfont: Mailpile by Brennan Novak
  * URL: http://github.com/mailpile/fonts
- * 
+ *
  * Mailpile font is licensed under the SIL Open Font License (OFL)
  * http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL
- * 
+ *
  * © 2013 Mailpile
 */
 @font-face {

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -8459,7 +8459,7 @@ tr.modal-tag-picker-item td.checkbox {
 #pile-results .message-details .header-cooked .header-value,
 #pile-results .thread-container .thread-message {
   display: block;
-  width: 245px;
+  width: 264px;
   margin: 0 10px;
   padding: 0px 2px;
   border: 0;
@@ -8636,11 +8636,11 @@ tr.modal-tag-picker-item td.checkbox {
 }
 #pile-results .full-message div.crypto-and-tags {
   white-space: normal;
-  padding-top: 10px;
+  padding-top: 2px;
 }
 #pile-results .full-message div.crypto-and-tags .pile-message-tag,
 #pile-results .full-message div.crypto-and-tags .icon.crypto {
-  display: block;
+  display: inline-block;
   margin: 0 0 5px 0;
   padding: 0;
   border: 0;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -8167,6 +8167,7 @@ tr.modal-tag-picker-item td.checkbox {
 }
 /* Pile */
 #pile-results {
+  table-layout: fixed;
   width: 100%;
   min-width: 800px;
   border-collapse: collapse;
@@ -8238,7 +8239,7 @@ tr.modal-tag-picker-item td.checkbox {
 #pile-results td.crypto-and-tags,
 #pile-results td.message-nav,
 #pile-results td.avatar {
-  min-width: 24px;
+  width: 24px;
   text-align: center;
   white-space: nowrap;
 }
@@ -8335,13 +8336,11 @@ tr.modal-tag-picker-item td.checkbox {
   color: #cccccc;
 }
 #pile-results td.subject {
-  min-width: 374px;
   overflow: hidden;
   word-wrap: normal;
   word-break: normal;
 }
 #pile-results td.subject a.item-subject {
-  width: 700px;
   display: block;
   white-space: nowrap;
   overflow: hidden;
@@ -9517,13 +9516,7 @@ a.modal-tag-color-option:hover {
     min-width: 300px;
   }
   #pile-results td.from {
-    width: 150px;
-  }
-  #pile-results td.subject {
-    min-width: 220px;
-  }
-  #pile-results td.subject a {
-    width: 214px;
+    width: 220px;
   }
   div.bulk-actions-hints {
     position: fixed;
@@ -9534,9 +9527,6 @@ a.modal-tag-color-option:hover {
   }
   #pile-results td.avatar {
     padding-left: 4px;
-  }
-  #pile-results td.subject a.item-subject {
-    width: 485px;
   }
   xtable,
   xtbody {
@@ -9847,9 +9837,7 @@ a.modal-tag-color-option:hover {
   #pile-results td.date {
     padding-right: 3px;
   }
-  #pile-results td.subject a.item-subject {
-    width: 370px;
-  }
+  /*  #pile-results td.subject a.item-subject { width: 370px; }*/
   #content-tools nav li {
     padding: 2px;
     margin: 0;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -8236,9 +8236,7 @@ tr.modal-tag-picker-item td.checkbox {
 #pile-results td.draggable:hover {
   cursor: move;
 }
-#pile-results td.crypto-and-tags,
 #pile-results td.message-nav {
-  width: 24px;
   text-align: center;
   white-space: nowrap;
 }
@@ -8259,14 +8257,17 @@ tr.modal-tag-picker-item td.checkbox {
   padding-top: 4px;
   padding-bottom: 3px;
 }
+#pile-results.comfy td.message-nav,
 #pile-results.comfy td.avatar {
   width: 32px;
   padding-right: 8px;
 }
+#pile-results.cozy td.message-nav,
 #pile-results.cozy td.avatar {
   width: 24px;
   padding-right: 6px;
 }
+#pile-results.snug td.message-nav,
 #pile-results.snug td.avatar {
   width: 18px;
   padding-right: 4px;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -8304,7 +8304,7 @@ tr.modal-tag-picker-item td.checkbox {
   font-size: 14px;
 }
 #pile-results td.from {
-  width: 255px;
+  width: 279px /* 255+24 */;
   overflow-x: hidden;
   word-wrap: normal;
   word-break: normal;
@@ -8634,12 +8634,12 @@ tr.modal-tag-picker-item td.checkbox {
   opacity: 0;
   transition: opacity 1s;
 }
-#pile-results .full-message td.crypto-and-tags {
+#pile-results .full-message div.crypto-and-tags {
   white-space: normal;
   padding-top: 10px;
 }
-#pile-results .full-message td.crypto-and-tags .pile-message-tag,
-#pile-results .full-message td.crypto-and-tags .icon.crypto {
+#pile-results .full-message div.crypto-and-tags .pile-message-tag,
+#pile-results .full-message div.crypto-and-tags .icon.crypto {
   display: block;
   margin: 0 0 5px 0;
   padding: 0;
@@ -8647,9 +8647,22 @@ tr.modal-tag-picker-item td.checkbox {
   font-size: 16px;
   line-height: 16px;
 }
-#pile-results .full-message td.crypto-and-tags .item-tags {
+#pile-results div.crypto-and-tags {
+  float: right;
+  text-align: right;
+}
+#pile-results .full-message div.crypto-and-tags .item-tags {
   display: block;
   margin-bottom: 0 0 5px 0;
+}
+#pile-results.snug div.crypto-and-tags {
+  padding-right: 4px;
+}
+#pile-results.cozy div.crypto-and-tags {
+  padding-right: 6px;
+}
+#pile-results.comfy div.crypto-and-tags {
+  padding-right: 8px;
 }
 #pile-results td.subject .message-container h3 {
   display: inline-block;
@@ -9842,10 +9855,10 @@ a.modal-tag-color-option:hover {
     display: block;
   }
   #pile-results td.checkbox,
-  #pile-results td.crypto-and-tags {
+  #pile-results div.crypto-and-tags {
     display: none;
   }
-  #pile-results td.from,
+  #pile-results td.rom,
   #pile-results td.date {
     padding-right: 3px;
   }
@@ -9963,8 +9976,8 @@ a.modal-tag-color-option:hover {
     width: 40px;
     height: 40px;
   }
-  #pile-results td.crypto-and-tags,
-  #pile-results.comfy td.crypto-and-tags {
+  #pile-results div.crypto-and-tags,
+  #pile-results.comfy div.crypto-and-tags {
     display: none;
   }
   #pile-results td.checkbox,

--- a/shared-data/default-theme/html/partials/pile_email_tags.html
+++ b/shared-data/default-theme/html/partials/pile_email_tags.html
@@ -1,0 +1,12 @@
+<span class="item-tags" style="opacity: 0.5"> {# FIXME #}
+    {% for tid in metadata.tag_tids %}
+      {% set tag = result.data.tags[tid] %}
+      {% if tag.label and not tag.searched %}
+    <span class="pile-message-tag pile-message-tag-{{tag.tid}}
+          color-{{tag.label_color}}"
+          data-tid="{{tag.tid}}" data-mid="{{mid}}">
+        <span class="icon pile-message-tag-icon {{tag.icon}}"></span>
+    </span>
+      {% endif %}
+    {% endfor %}
+</span>

--- a/shared-data/default-theme/html/partials/search_item.html
+++ b/shared-data/default-theme/html/partials/search_item.html
@@ -127,7 +127,6 @@
   {%- if thread|length > 1 %}
     {%- include "partials/pile_threading.html" %}
   {%- endif %}
-  </td>
 {% else %}
   <td class="avatar">
     <a><img src="{{ show_avatar(from) }}"></a>
@@ -145,9 +144,8 @@
       {% if metadata.flags.forwarded %}<span class="icon-forward"></span>{% endif %}
       {% endif %}
     </a>
-  </td>
 {%endif %}
-  <td class="crypto-and-tags">
+    <div class="crypto-and-tags">
     <span class="item-tags" style="opacity: 0.5"> {# FIXME #}
     {% for tid in metadata.tag_tids %}
       {% set tag = result.data.tags[tid] %}
@@ -168,6 +166,7 @@
     <span class="icon crypto icon-lock-closed color-12-red"></span>
     {% endif %}
   {%- endif %}
+    </div>
   </td>
   <td class="subject">
 {%- if message_errors %}

--- a/shared-data/default-theme/html/partials/search_item.html
+++ b/shared-data/default-theme/html/partials/search_item.html
@@ -146,19 +146,7 @@
     </a>
 {%endif %}
     <div class="crypto-and-tags">
-    <span class="item-tags" style="opacity: 0.5"> {# FIXME #}
-    {% for tid in metadata.tag_tids %}
-      {% set tag = result.data.tags[tid] %}
-      {% if tag.label and not tag.searched %}
-      <span class="pile-message-tag pile-message-tag-{{tag.tid}}
-                   color-{{tag.label_color}}"
-            data-tid="{{tag.tid}}" data-mid="{{mid}}">
-        <span class="icon pile-message-tag-icon {{tag.icon}}"></span>
-      </span>
-      {% endif %}
-    {% endfor %}
-    </span>
-
+      {%- include "partials/pile_email_tags.html" %}
   {%- if not message %}
     {% if metadata.crypto.encryption in ('decrypted', 'mixed-decrypted', 'lockedkey', 'mixed-lockedkey') %}
     <span class="icon crypto icon-lock-closed color-08-green"></span>

--- a/shared-data/default-theme/html/partials/search_item.html
+++ b/shared-data/default-theme/html/partials/search_item.html
@@ -89,6 +89,9 @@
 {%- endif %}
             <li class="action"><a title="{{_("Private Reply")}}" class="message-action-reply" data-mid="{{mid}}" href="#"><span class="icon icon-reply"></span></a></li>
           </ul>
+          <div class="crypto-and-tags">
+            {%- include "partials/pile_email_tags.html" %}
+          </div>
         </h3>
         <span class="header-value" title='{{metadata.from.fn}} &lt;{{metadata.from.address}}&gt;'>
           <span class="address-avatar"><img src="{{ show_avatar(metadata.from) }}"></span>
@@ -145,9 +148,9 @@
       {% endif %}
     </a>
 {%endif %}
+  {%- if not message and not message_errors %}
     <div class="crypto-and-tags">
       {%- include "partials/pile_email_tags.html" %}
-  {%- if not message %}
     {% if metadata.crypto.encryption in ('decrypted', 'mixed-decrypted', 'lockedkey', 'mixed-lockedkey') %}
     <span class="icon crypto icon-lock-closed color-08-green"></span>
     {% elif metadata.crypto.encryption in ('error', 'mixed-error', 'missingkey', 'mixed-missingkey') %}

--- a/shared-data/default-theme/less/app/mobile.less
+++ b/shared-data/default-theme/less/app/mobile.less
@@ -222,8 +222,8 @@
   }
 
   #pile-results td.checkbox,
-  #pile-results td.crypto-and-tags { display: none; }
-  #pile-results td.from,
+  #pile-results div.crypto-and-tags { display: none; }
+  #pile-results td.rom,
   #pile-results td.date { padding-right: 3px; }
 
 /*  #pile-results td.subject a.item-subject { width: 370px; }*/
@@ -302,7 +302,7 @@
         margin: 5px 5px 5px 0px;
         width: 40px; height: 40px; }
     }
-    td.crypto-and-tags { display: none; }
+    div.crypto-and-tags { display: none; }
     td.checkbox { display: none; }
     td.date { position: absolute; top: 0px; right: 5px; pull: right; }
     td.from {

--- a/shared-data/default-theme/less/app/mobile.less
+++ b/shared-data/default-theme/less/app/mobile.less
@@ -226,7 +226,7 @@
   #pile-results td.from,
   #pile-results td.date { padding-right: 3px; }
 
-  #pile-results td.subject a.item-subject { width: 370px; }
+/*  #pile-results td.subject a.item-subject { width: 370px; }*/
 
   #content-tools nav li { padding: 2px; margin: 0; }
   #content-tools nav .navigation-text { display: none; }

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -141,7 +141,7 @@
     #pile-results td.subject .message-container { max-width: 214px; }}
 
   #pile-results td.date {
-    width: 60px;
+    width: 80px;
     text-align: right;
     white-space: nowrap;
     color: @gray;

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -68,7 +68,7 @@
   #pile-results.snug td.message-nav span.icon { font-size: 14px; }
 
   #pile-results td.from {
-    width: 255px;
+    width: 279px /* 255+24 */;
     overflow-x: hidden;
     word-wrap: normal;
     word-break: normal;
@@ -376,19 +376,36 @@
     transition: opacity 1s;
   }
 
-  #pile-results .full-message td.crypto-and-tags {
+  #pile-results .full-message div.crypto-and-tags {
     white-space: normal;
     padding-top: 10px;
   }
 
-  #pile-results .full-message td.crypto-and-tags .pile-message-tag,
-  #pile-results .full-message td.crypto-and-tags .icon.crypto {
+  #pile-results .full-message div.crypto-and-tags .pile-message-tag,
+  #pile-results .full-message div.crypto-and-tags .icon.crypto {
     display: block; margin: 0 0 5px 0; padding: 0; border: 0;
     font-size: 16px; line-height: 16px;
   }
 
-  #pile-results .full-message td.crypto-and-tags .item-tags {
+  #pile-results div.crypto-and-tags {
+    float: right;
+    text-align: right;
+  }
+
+  #pile-results .full-message div.crypto-and-tags .item-tags {
     display: block; margin-bottom: 0 0 5px 0;
+  }
+
+  #pile-results.snug div.crypto-and-tags {
+    padding-right: 4px;
+  }
+
+  #pile-results.cozy div.crypto-and-tags {
+    padding-right: 6px;
+  }
+
+  #pile-results.comfy div.crypto-and-tags {
+    padding-right: 8px;
   }
 
   #pile-results td.subject .message-container h3 {

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -1,6 +1,7 @@
         /* Pile */
 
   #pile-results {
+    table-layout: fixed;
     width: 100%;
     min-width: 800px;
     border-collapse: collapse;
@@ -41,7 +42,7 @@
   #pile-results        td.draggable:hover { cursor: move; }
   #pile-results        td.crypto-and-tags,
   #pile-results        td.message-nav,
-  #pile-results        td.avatar       { min-width: 24px; text-align: center; white-space: nowrap; }
+  #pile-results        td.avatar       { width: 24px; text-align: center; white-space: nowrap; }
   #pile-results        td.avatar a     { display: block; text-align: center; }
   #pile-results        td.avatar a img { display: inline-block; border-radius: 2px; }
 
@@ -111,14 +112,12 @@
   }
 
   #pile-results td.subject {
-    min-width: 374px;
     overflow: hidden;
     word-wrap: normal;
     word-break: normal;
   }
 
   #pile-results td.subject a.item-subject {
-    width: 700px;
     display: block;
     white-space: nowrap;
     overflow: hidden;

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -40,16 +40,19 @@
 
   #pile-results        td.draggable       { width: 12px; cursor: move; }
   #pile-results        td.draggable:hover { cursor: move; }
-  #pile-results        td.crypto-and-tags,
-  #pile-results        td.message-nav { width: 24px; text-align: center; white-space: nowrap; }
+  #pile-results        td.message-nav { text-align: center; white-space: nowrap; }
   #pile-results        td.avatar a     { display: block; text-align: center; }
   #pile-results        td.avatar a img { display: inline-block; border-radius: 2px; }
 
   #pile-results.comfy  td.avatar,
   #pile-results.cozy   td.avatar { padding-top: 6px; padding-bottom: 5px; }
   #pile-results.snug   td.avatar { padding-top: 4px; padding-bottom: 3px; }
+
+  #pile-results.comfy  td.message-nav,
   #pile-results.comfy  td.avatar { width: 32px; padding-right: 8px; }
+  #pile-results.cozy   td.message-nav,
   #pile-results.cozy   td.avatar { width: 24px; padding-right: 6px; }
+  #pile-results.snug   td.message-nav,
   #pile-results.snug   td.avatar { width: 18px; padding-right: 4px; }
   #pile-results.comfy  td.avatar a img { width: 24px; height: 24px; }
   #pile-results.cozy   td.avatar a img { width: 18px; height: 18px; }

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -41,14 +41,16 @@
   #pile-results        td.draggable       { width: 12px; cursor: move; }
   #pile-results        td.draggable:hover { cursor: move; }
   #pile-results        td.crypto-and-tags,
-  #pile-results        td.message-nav,
-  #pile-results        td.avatar       { width: 24px; text-align: center; white-space: nowrap; }
+  #pile-results        td.message-nav { width: 24px; text-align: center; white-space: nowrap; }
   #pile-results        td.avatar a     { display: block; text-align: center; }
   #pile-results        td.avatar a img { display: inline-block; border-radius: 2px; }
 
   #pile-results.comfy  td.avatar,
   #pile-results.cozy   td.avatar { padding-top: 6px; padding-bottom: 5px; }
   #pile-results.snug   td.avatar { padding-top: 4px; padding-bottom: 3px; }
+  #pile-results.comfy  td.avatar { width: 32px; padding-right: 8px; }
+  #pile-results.cozy   td.avatar { width: 24px; padding-right: 6px; }
+  #pile-results.snug   td.avatar { width: 18px; padding-right: 4px; }
   #pile-results.comfy  td.avatar a img { width: 24px; height: 24px; }
   #pile-results.cozy   td.avatar a img { width: 18px; height: 18px; }
   #pile-results.snug   td.avatar a img { width: 14px; height: 14px; }

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -214,7 +214,7 @@
   #pile-results .message-details .header-cooked .header-value,
   #pile-results .thread-container .thread-message {
     display: block;
-    width: 245px;
+    width: 264px;
     margin: 0 10px;
     padding: 0px 2px;
     border: 0;
@@ -378,12 +378,12 @@
 
   #pile-results .full-message div.crypto-and-tags {
     white-space: normal;
-    padding-top: 10px;
+    padding-top: 2px;
   }
 
   #pile-results .full-message div.crypto-and-tags .pile-message-tag,
   #pile-results .full-message div.crypto-and-tags .icon.crypto {
-    display: block; margin: 0 0 5px 0; padding: 0; border: 0;
+    display: inline-block; margin: 0 0 5px 0; padding: 0; border: 0;
     font-size: 16px; line-height: 16px;
   }
 

--- a/shared-data/default-theme/less/app/pile.less
+++ b/shared-data/default-theme/less/app/pile.less
@@ -556,5 +556,3 @@
     font-size: 14px;
     font-weight: bold;
   }
-
-

--- a/shared-data/default-theme/less/app/tablet.less
+++ b/shared-data/default-theme/less/app/tablet.less
@@ -4,7 +4,7 @@
   /* Make logo into just icon */
   .topbar-logo { width: 90px; overflow: hidden; }
   .topbar-logo-name { display: none; }
-  
+
   /* Shrink the sidebar a bit, but keep it. */
   #sidebar { width: 180px; }
   #sidebar-wrapper { width: 179px; font-size: 0.7em; }
@@ -27,15 +27,12 @@
 
   /* Pile */
   #pile-results { min-width: 300px; }
-  #pile-results td.from { width: 150px; }
-  #pile-results td.subject { min-width: 220px; }
-  #pile-results td.subject a { width: 214px; }
+  #pile-results td.from { width: 220px; }
   div.bulk-actions-hints { position: fixed; top: -100px; }
 
   #pile-results xtd.draggable { display: none; }
   #pile-results td.avatar { padding-left: 4px; }
 
-  #pile-results td.subject a.item-subject { width: 485px; }
 
   xtable, xtbody { display: block; white-space: normal; width: 100%; }
   xtr { display: block; height: auto; width: 100%; }

--- a/shared-data/default-theme/less/app/webfonts.less
+++ b/shared-data/default-theme/less/app/webfonts.less
@@ -3,41 +3,41 @@
 
 /* @license
  * Mailpile font designed for Mailpile
- * 
+ *
  * You may obtain a copy of the license at the URLs below.
- * 
+ *
  * Webfont: Mailpile by Brennan Novak
  * URL: http://github.com/mailpile/fonts
- * 
+ *
  * Mailpile font is licensed under the SIL Open Font License (OFL)
  * http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL
- * 
+ *
  * © 2013 Mailpile
 */
 
 @font-face {
-	font-family: 'Mailpile-300'; 
-	src: url('../../webfonts/Mailpile-Normal.eot'); 
-	src: url('../../webfonts/Mailpile-Normal.eot?#iefix') format('embedded-opentype'), 
-	url('../../webfonts/Mailpile-Normal.woff') format('font-woff'), 
-	url('../../webfonts/Mailpile-Normal.ttf') format('truetype'), 
+	font-family: 'Mailpile-300';
+	src: url('../../webfonts/Mailpile-Normal.eot');
+	src: url('../../webfonts/Mailpile-Normal.eot?#iefix') format('embedded-opentype'),
+	url('../../webfonts/Mailpile-Normal.woff') format('font-woff'),
+	url('../../webfonts/Mailpile-Normal.ttf') format('truetype'),
 	url('../../webfonts/Mailpile-Normal.svg#wf') format('svg');
 }
 
 @font-face {
-	font-family: 'Mailpile-500'; 
-	src: url('../../webfonts/Mailpile-500.eot'); 
-	src: url('../../webfonts/Mailpile-500.eot?#iefix') format('embedded-opentype'), 
-	url('../../webfonts/Mailpile-500.woff') format('font-woff'), 
-	url('../../webfonts/Mailpile-500.ttf') format('truetype'), 
+	font-family: 'Mailpile-500';
+	src: url('../../webfonts/Mailpile-500.eot');
+	src: url('../../webfonts/Mailpile-500.eot?#iefix') format('embedded-opentype'),
+	url('../../webfonts/Mailpile-500.woff') format('font-woff'),
+	url('../../webfonts/Mailpile-500.ttf') format('truetype'),
 	url('../../webfonts/Mailpile-500.svg#wf') format('svg');
 }
 
 @font-face {
-	font-family: 'Mailpile-700'; 
-	src: url('../../webfonts/Mailpile-700.eot'); 
-	src: url('../../webfonts/Mailpile-700.eot?#iefix') format('embedded-opentype'), 
-	url('../../webfonts/Mailpile-700.woff') format('font-woff'), 
-	url('../../webfonts/Mailpile-700.ttf') format('truetype'), 
+	font-family: 'Mailpile-700';
+	src: url('../../webfonts/Mailpile-700.eot');
+	src: url('../../webfonts/Mailpile-700.eot?#iefix') format('embedded-opentype'),
+	url('../../webfonts/Mailpile-700.woff') format('font-woff'),
+	url('../../webfonts/Mailpile-700.ttf') format('truetype'),
 	url('../../webfonts/Mailpile-700.svg#wf') format('svg');
 }


### PR DESCRIPTION
Horizontal in mailpile have been annoying me for a while, so I decided to dig that issue :-).

After hours of struggling, experimenting and reading, I figured out that the "auto" `<table>` sizing makes it quite impossible to prevent the table from overflowing. Unless you know what your content looks like by advance (which is not the case with mailpile, for example mail subjects with very long words mess up table sizing).

For the record, #1765 seemed to solve some scrollbar issues, and introduced others.

See detailed commit messages for details.

PS: I tried several approaches. One of them included to "escape" the unfolded message line from the main table, so that it do not share the columns widths with folded messages (different data, different column set), but I figured out a simpler solution. I keep that idea of having different column size for a later PR, maybe. But I already know that @BjarniRunar is attached to the same-sized columns among message summary and expanded message.
