### PR TITLE
Enhance footer layout on smartphone

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -9926,7 +9926,8 @@ a.modal-tag-color-option:hover {
   }
   /* Stuff we just hide... */
   #sidebar hr,
-  #notifications-header {
+  #notifications-header,
+  #pile-speed {
     display: none;
   }
   #pile-results,
@@ -10051,10 +10052,6 @@ a.modal-tag-color-option:hover {
   }
   div.footer-nav {
     display: none;
-  }
-  #pile-speed {
-    margin-bottom: 0px;
-    font-size: 70%;
   }
   #display-density-selector {
     display: none;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -10059,6 +10059,18 @@ a.modal-tag-color-option:hover {
   #pile-more {
     display: none;
   }
+  #pile-bottom .button-primary {
+    width: 49.3%;
+    float: none;
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  /* Single  footer button case */
+  #pile-previous.button-primary:last-of-type,
+  #pile-next.button-primary:nth-of-type(2) {
+    width: 100%;
+  }
   table.account-list {
     margin: 0 0 !important;
     display: block;

--- a/shared-data/default-theme/less/app/mobile.less
+++ b/shared-data/default-theme/less/app/mobile.less
@@ -278,7 +278,8 @@
 
   /* Stuff we just hide... */
   #sidebar hr,
-  #notifications-header {
+  #notifications-header,
+  #pile-speed{
     display: none;
   }
 
@@ -359,11 +360,6 @@
 
   div.footer-nav {
     display: none;
-  }
-
-  #pile-speed {
-    margin-bottom: 0px;
-    font-size: 70%;
   }
 
   #display-density-selector {

--- a/shared-data/default-theme/less/app/mobile.less
+++ b/shared-data/default-theme/less/app/mobile.less
@@ -370,6 +370,20 @@
       display: none;
   }
 
+  #pile-bottom .button-primary {
+     width: 49.3%;
+     float: none;
+     text-align: center;
+     margin-left: auto;
+     margin-right: auto;
+  }
+
+  /* Single  footer button case */
+  #pile-previous.button-primary:last-of-type,
+  #pile-next.button-primary:nth-of-type(2) {
+    width: 100%;
+  }
+
   table.account-list {
       margin: 0 0 !important;
       display: block;


### PR DESCRIPTION
Using existing mediaqueries.

I think the speedometer is a nice gadget, but it does not worth the screen space it takes on a smartphone display.

## Before

![image](https://user-images.githubusercontent.com/429633/28585632-1b4dd834-7171-11e7-9a4a-541cb2c194b8.png)

## After

![image](https://user-images.githubusercontent.com/429633/28585586-f0a87580-7170-11e7-874b-306cce14ff0d.png)

Relates #1868 

@smari as you pushed most of the other responsive stuff, what do you think of this one ?