### PR TITLE
Use .text to print doc objectify.StringElement

### DIFF
--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -575,7 +575,7 @@ class SetupGetEmailSettings(TestableWebbable):
                         result['docs'] = result.get('docs', [])
                         result['docs'].append({
                             'url': docs.get('url', ''),
-                            'description': str(docs.descr)
+                            'description': docs.descr.text
                         })
                 except AttributeError:
                     pass


### PR DESCRIPTION
Autoconfig's xml documentation element may contain localization
strings [1]. If these strings contain non-ascii characters, e.g.
greek, autoconfig xml parsing will produce UnicodeEncodeError
exception and mailpile's account setup autoconfiguration will
fail.

This is due to the string casting of the objectify.StringElement.
This commit uses the .text method to print either type str or type
unicode.

[1]: https://autoconfig.thunderbird.net/v1.1/freenet.de