### PR TITLE
#1844: Search-bar Firefox font cutoff tweak

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -6915,8 +6915,8 @@ div.notification-bubble span.action {
 }
 .form-search input {
   width: 282px;
-  height: 18px;
-  padding: 9px 12px;
+  height: 20px;
+  padding: 9px 12px 7px 12px;
   float: left;
   font: normal 18px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
   border: 0;

--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -6916,7 +6916,7 @@ div.notification-bubble span.action {
 .form-search input {
   width: 282px;
   height: 20px;
-  padding: 9px 12px 7px 12px;
+  padding: 8px 12px;
   float: left;
   font: normal 18px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
   border: 0;

--- a/shared-data/default-theme/less/app/topbar.less
+++ b/shared-data/default-theme/less/app/topbar.less
@@ -60,8 +60,8 @@
 
   .form-search input {
     width: 282px;
-    height: 18px;
-    padding: 9px 12px;
+    height: 20px;
+    padding: 9px 12px 7px 12px;
     float: left;    
     font: normal 18px @text-font-family-bold;
     border: 0;

--- a/shared-data/default-theme/less/app/topbar.less
+++ b/shared-data/default-theme/less/app/topbar.less
@@ -61,7 +61,7 @@
   .form-search input {
     width: 282px;
     height: 20px;
-    padding: 9px 12px 7px 12px;
+    padding: 8px 12px;
     float: left;    
     font: normal 18px @text-font-family-bold;
     border: 0;


### PR DESCRIPTION
Fixes #1844.

Tweaked height and padding of search-bar so that Firefox doesn't cut off the bottom of letters like 'g' or 'j'. Tested in Chrome as well; if someone can confirm other major browsers, that would be great.