### PR TITLE
Add missing lock on mail index

### DIFF
--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -319,14 +319,15 @@ class MailIndex(BaseIndex):
 
     def update_ptrs_and_msgids(self, session):
         session.ui.mark(_('Updating high level indexes'))
-        for offset in range(0, len(self.INDEX)):
-            message = self.l2m(self.INDEX[offset])
-            if len(message) == self.MSG_FIELDS_V2:
-                self.MSGIDS[message[self.MSG_ID]] = offset
-                for msg_ptr in message[self.MSG_PTRS].split(','):
-                    self.PTRS[msg_ptr] = offset
-            else:
-                session.ui.warning(_('Bogus line: %s') % line)
+        with self._lock:
+            for offset in range(0, len(self.INDEX)):
+                message = self.l2m(self.INDEX[offset])
+                if len(message) == self.MSG_FIELDS_V2:
+                    self.MSGIDS[message[self.MSG_ID]] = offset
+                    for msg_ptr in message[self.MSG_PTRS].split(','):
+                        self.PTRS[msg_ptr] = offset
+                else:
+                    session.ui.warning(_('Bogus line: %s') % line)
 
     def _remove_location(self, session, msg_ptr):
         msg_idx_pos = self.PTRS[msg_ptr]


### PR DESCRIPTION
`update_ptrs_and_msgids()` seems to require consistent state of `self.INDEX`,
`self.MSGIDS` and `self.PTRS`. However, there is no lock to enforce it, neither in
`update_ptrs_and_msgids()` nor in its caller, `scan_mailbox()`.

Just wondering, that is the first time I read this part of the code. Is my analysis relevant ?