### PR TITLE
Fix crash of smtp_client when utf-8 received + rename last /usr/bin/python to /bin/env python2

### DIFF
--- a/mailpile/plugins/vcard_mork.py
+++ b/mailpile/plugins/vcard_mork.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #coding:utf-8
 import sys
 import re

--- a/mailpile/smtp_client.py
+++ b/mailpile/smtp_client.py
@@ -1,3 +1,4 @@
+#coding:utf-8
 import random
 import hashlib
 import smtplib


### PR DESCRIPTION
After those two changes Mailpile works fine on my system