### PR TITLE
Issue 1813

### DIFF
--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -152,7 +152,6 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
       FilesAdded: function(up, files) {
         // Loop through added files
         plupload.each(files, function(file) {
-
           // Show warning for ~20MB or larger
           if ((file.size < 200000000) ||
               confirm(file.name + ' {{_("is")|escapejs}} ' + plupload.formatSize(file.size) + '.\n' +
@@ -171,8 +170,14 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
       },
       UploadProgress: function(up, file) {
         $('#' + file.id).find('b').html('<span>' + file.percent + '%</span>');
-        var progressBar = "<progress value="+file.percent+" max='100'></progress> "+file.percent+"%";
-        $('.attachment-progress-bar').html(progressBar);
+	if (file.percent < 100) {
+          var progressBar = "<progress value="+file.percent+" max='100'></progress> "+file.percent+"%";
+	}
+	else {
+	  var progressBar = "Processing Upload...";
+	}
+        //$('.attachment-progress-bar').html(progressBar);
+	Mailpile.notification({status: 'info', message: progressBar, event_id: "Upload-" + file.id });
       },
       FileUploaded: function(up, file, response) {
         if (response.status == 200) {
@@ -181,7 +186,8 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
           var new_mid = response_json.result.message_ids[0];
 
           //console.log(file);
-          $('.attachment-progress-bar').empty();
+          //$('.attachment-progress-bar').empty();
+	  Mailpile.notification({status: 'info', message: "Finished uploading " + file.name, event_id: "Upload-" + file.id, flags: "c" });
           Mailpile.Composer.Attachments.UpdatePreviews(response_json.result.data.messages[new_mid].attachments, settings.mid, file);
 
         } else {
@@ -198,6 +204,8 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
         Mailpile.notification({status: 'error', message: '{{_("Could not upload attachment because")|escapejs}}: ' + err.message });
         $('#' + err.file.id).find('b').html('Failed ' + err.code);
         uploader.refresh();
+	//$('.attachment-progress-bar').empty();
+	Mailpile.notification({status: 'error', message: "Failed to upload " + file.name, event_id: "Upload-" + file.id });
         Mailpile.Composer.Attachments.Uploader.uploading -= 1;
         if (Mailpile.Composer.Attachments.Uploader.uploading < 1) {
           $('#form-compose-' + settings.mid + ' button.compose-action'

--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -152,6 +152,7 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
       FilesAdded: function(up, files) {
         // Loop through added files
         plupload.each(files, function(file) {
+
           // Show warning for ~20MB or larger
           if ((file.size < 200000000) ||
               confirm(file.name + ' {{_("is")|escapejs}} ' + plupload.formatSize(file.size) + '.\n' +
@@ -171,13 +172,13 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
       UploadProgress: function(up, file) {
         $('#' + file.id).find('b').html('<span>' + file.percent + '%</span>');
 	if (file.percent < 100) {
-          var progressBar = "<progress value="+file.percent+" max='100'></progress> "+file.percent+"%";
+          var progress = "<progress value="+file.percent+" max='100'></progress> "+file.percent+"%";
 	}
 	else {
-	  var progressBar = "Processing Upload...";
+	  var progress = "Processing Upload...";
 	}
         //$('.attachment-progress-bar').html(progressBar);
-	Mailpile.notification({status: 'info', message: progressBar, event_id: "Upload-" + file.id });
+	Mailpile.notification({status: 'info', message: progress, event_id: "Upload-" + file.id });
       },
       FileUploaded: function(up, file, response) {
         if (response.status == 200) {


### PR DESCRIPTION
Moves upload progress bar to notification. No longer stalls at 100%, displays "Processing upload..." instead. When an upload fails, notification should tell user (progress bar removed), although I don't know how to test this. When upload is complete, notification tells user and is flagged complete ("c"), so it disappears after 8 seconds. 

I used file id to uniquely identify each upload notification. There may be a better way to do this. 