### PR TITLE
mailpile/util/CleanText: allow '-' in NONPATH

### DIFF
--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -973,7 +973,7 @@ class CleanText:
                                         set(range(ord('0'), ord('9') + 1)) -
                                         set(range(ord('a'), ord('z') + 1)) -
                                         set(range(ord('A'), ord('Z') + 1)) -
-                                        set([ord('_'), ord('/')]))])
+                                        set([ord('-'), ord('_'), ord('/')]))])
 
     def __init__(self, text, banned='', replace=''):
         self.clean = str("".join([i if (((ord(i) > 31 and ord(i) < 127) or


### PR DESCRIPTION
This pull requests adds `-` to the allowed characters in the `NONPATH` specification of the `CleanText` class.