### PR TITLE
Tools for managing multiple Mailpiles on one machine re #877

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -187,9 +187,11 @@ def Main(args):
         session.main = True
         try:
             CatchUnixSignals(session)
-            config.clean_tempfile_dir()
+            config.clean_tempfile_dir()     # *** What if this is 2nd Mailpile.
             config.load(session)
+            print 'TTTTT'
         except IOError:
+            print 'UUUUU', config.sys.lockdown
             if config.sys.debug:
                 session.ui.error(_('Failed to decrypt configuration, '
                                    'please log in!'))
@@ -199,7 +201,7 @@ def Main(args):
         session.ui.error('Access denied: %s\n' % e)
         sys.exit(1)
 
-    print 'AAAAA' # *** DEBUG
+    print 'AAAAA', config.sys.lockdown
 
     try:
         try:
@@ -246,6 +248,11 @@ def Main(args):
         traceback.print_exc()
 
     finally:
+    
+        print 'BBBBB',config.sys.lockdown
+        if isinstance(config.lock_workdir, str):
+            pass
+    
         if readline is not None:
             readline.write_history_file(session.config.history_file())
 

--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -187,11 +187,9 @@ def Main(args):
         session.main = True
         try:
             CatchUnixSignals(session)
-            config.clean_tempfile_dir()     # *** What if this is 2nd Mailpile.
+            config.clean_tempfile_dir()
             config.load(session)
-            print 'TTTTT'
         except IOError:
-            print 'UUUUU', config.sys.lockdown
             if config.sys.debug:
                 session.ui.error(_('Failed to decrypt configuration, '
                                    'please log in!'))
@@ -200,8 +198,6 @@ def Main(args):
     except AccessError, e:
         session.ui.error('Access denied: %s\n' % e)
         sys.exit(1)
-
-    print 'AAAAA', config.sys.lockdown
 
     try:
         try:
@@ -248,11 +244,6 @@ def Main(args):
         traceback.print_exc()
 
     finally:
-    
-        print 'BBBBB',config.sys.lockdown
-        if isinstance(config.lock_workdir, str):
-            pass
-    
         if readline is not None:
             readline.write_history_file(session.config.history_file())
 

--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -199,6 +199,8 @@ def Main(args):
         session.ui.error('Access denied: %s\n' % e)
         sys.exit(1)
 
+    print 'AAAAA' # *** DEBUG
+
     try:
         try:
             if '--login' in args:

--- a/mailpile/config/defaults.py
+++ b/mailpile/config/defaults.py
@@ -35,6 +35,8 @@ CONFIG_RULES = {
         'history_length': (_('History length (lines, <0=no save)'), int,  100),
         'http_host':     p(_('Listening host for web UI'),
                            'hostname', 'localhost'),
+        'http_port_min': p(_('Min random port for web UI'), int,        32769),
+        'http_port_max': p(_('Max random port for web UI'), int,        39999),
         'http_port':     p(_('Listening port for web UI'), int,         33411),
         'http_path':     p(_('HTTP path of web UI'), 'webroot',            ''),
         'http_no_auth':  X(_('Disable HTTP authentication'),      bool, False),

--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -70,7 +70,7 @@ class ConfigManager(ConfigDict):
             return workdir
 
         # Which pile?
-        pile = os.getenv('MAILPILE_PILENAME', 'default')
+        pile = os.getenv('MAILPILE_PILENAME')
         if not pile:
             # Legacy env variable (PROFILE here means pile)
             pile = os.getenv('MAILPILE_PROFILE', 'default')

--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -69,22 +69,25 @@ class ConfigManager(ConfigDict):
         if workdir:
             return workdir
 
-        # Which profile?
-        profile = os.getenv('MAILPILE_PROFILE', 'default')
+        # Which pile?
+        pile = os.getenv('MAILPILE_PILENAME', 'default')
+        if not pile:
+            # Legacy env variable (PROFILE here means pile)
+            pile = os.getenv('MAILPILE_PROFILE', 'default')
 
         # Check if we have a legacy setup we need to preserve
-        workdir = self.LEGACY_DEFAULT_WORKDIR(profile)
+        workdir = self.LEGACY_DEFAULT_WORKDIR(pile)
         if not AppDirs or (os.path.exists(workdir) and os.path.isdir(workdir)):
             return workdir
 
         # Use platform-specific defaults
         # via https://github.com/ActiveState/appdirs
         dirs = AppDirs("Mailpile", "Mailpile ehf")
-        return os.path.join(dirs.user_data_dir, profile)
+        return os.path.join(dirs.user_data_dir, pile)
 
     @classmethod
-    def LEGACY_DEFAULT_WORKDIR(self, profile):
-        if profile == 'default':
+    def LEGACY_DEFAULT_WORKDIR(self, pile):
+        if pile == 'default':
             # Backwards compatibility: If the old ~/.mailpile exists, use it.
             workdir = os.path.expanduser('~/.mailpile')
             if os.path.exists(workdir) and os.path.isdir(workdir):
@@ -102,7 +105,7 @@ class ConfigManager(ConfigDict):
             basedir = os.getenv('XDG_DATA_HOME',
                                 os.path.expanduser('~/.local/share'))
 
-        return os.path.join(basedir, 'Mailpile', profile)
+        return os.path.join(basedir, 'Mailpile', pile)
 
     @classmethod
     def DEFAULT_SHARED_DATADIR(self):
@@ -224,7 +227,7 @@ class ConfigManager(ConfigDict):
             else:
                 if session:
                     session.ui.error(_('Another Mailpile or program is'
-                                       ' using the profile directory'))
+                                       ' using the pile data directory'))
                 sys.exit(1)
 
     def parse_config(self, session, data, source='internal'):

--- a/mailpile/plugins/__init__.py
+++ b/mailpile/plugins/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
     'setup_magic', 'oauth', 'exporters', 'plugins', 'motd',
     'vcard_carddav', 'vcard_gnupg', 'vcard_gravatar', 'vcard_libravatar',
     'vcard_mork', 'html_magic', 'migrate', 'smtp_server', 'crypto_policy',
-    'keylookup', 'webterminal'
+    'keylookup', 'webterminal','discover'
 ]
 PLUGINS = __all__
 

--- a/mailpile/plugins/core.py
+++ b/mailpile/plugins/core.py
@@ -35,7 +35,10 @@ from mailpile.search import MailIndex
 from mailpile.util import *
 from mailpile.vcard import AddressInfo
 from mailpile.vfs import vfs, FilePath
-from mailpile.plugins.discover import discover_piles
+try:
+    from mailpile.plugins.discover import discover_piles
+except:
+    discover_piles = None
 
 _plugins = PluginManager(builtin=__file__)
 

--- a/mailpile/plugins/core.py
+++ b/mailpile/plugins/core.py
@@ -35,6 +35,7 @@ from mailpile.search import MailIndex
 from mailpile.util import *
 from mailpile.vcard import AddressInfo
 from mailpile.vfs import vfs, FilePath
+from mailpile.plugins.discover import discover_piles
 
 _plugins = PluginManager(builtin=__file__)
 
@@ -416,7 +417,7 @@ class BrowseOrLaunch(Command):
                      config.sys.http_path or '')
 
         try:
-            #*** DEBUG socket.create_connection(sspec[:2])
+            socket.create_connection(sspec[:2])
             self.Browse(sspec)
             os._exit(127)
         except IOError:

--- a/mailpile/plugins/discover.py
+++ b/mailpile/plugins/discover.py
@@ -125,7 +125,7 @@ class Discover(Command):
     """Discover Mailpile piles accessible on this machine"""
     SYNOPSIS = (None, 'discover', None,
                     '[--user=<user1[,user2 ...]] [--pile=<pile1[,pile2 ...]]')
-    ORDER = ('Internals', 5)
+    ORDER = ('Internals', 9)
     CONFIG_REQUIRED = False
     IS_USER_ACTIVITY = True
     COMMAND_SECURITY = security.CC_BROWSE_FILESYSTEM

--- a/mailpile/plugins/discover.py
+++ b/mailpile/plugins/discover.py
@@ -1,5 +1,5 @@
 # This code searches a computer for Mailpile pile directories
-# and prints a summary of their location and associated ports.
+# and prints a summary of their locations and associated ports.
 # 
 # Copyright (C) 2018 Jack Dodds
 # This code is part of Mailpile and is hereby released under the
@@ -11,161 +11,158 @@ import sys
 import getpass
 import ConfigParser
 import fasteners
-import mailpile.config.defaults as mpdefaults
 
-
-import datetime
-import json
+#import datetime
+#import json
 import random
-import re
-import socket
-import subprocess
-import traceback
-import threading
-import time
-import webbrowser
-
-import mailpile.util
-import mailpile.postinglist
-import mailpile.security as security
+#import re
+#import socket
+#import subprocess
+#import traceback
+#import threading
+#import time
+#import webbrowser
+#import mailpile.util
+#import mailpile.postinglist
+#import mailpile.security as security
 from mailpile.commands import *
-from mailpile.config.validators import WebRootCheck
-from mailpile.crypto.gpgi import GnuPG
-from mailpile.eventlog import Event
+#from mailpile.config.validators import WebRootCheck
+#from mailpile.crypto.gpgi import GnuPG
+#from mailpile.eventlog import Event
 from mailpile.i18n import gettext as _
 from mailpile.i18n import ngettext as _n
-from mailpile.mailboxes import IsMailbox
-from mailpile.mailutils import ClearParseCache, Email
-from mailpile.postinglist import GlobalPostingList
+#from mailpile.mailboxes import IsMailbox
+#from mailpile.mailutils import ClearParseCache, Email
+#from mailpile.postinglist import GlobalPostingList
 from mailpile.plugins import PluginManager
-from mailpile.safe_popen import MakePopenUnsafe, MakePopenSafe
-from mailpile.search import MailIndex
-from mailpile.util import *
-from mailpile.vcard import AddressInfo
-from mailpile.vfs import vfs, FilePath
+#from mailpile.safe_popen import MakePopenUnsafe, MakePopenSafe
+#from mailpile.search import MailIndex
+#from mailpile.util import *
+#from mailpile.vcard import AddressInfo
+#from mailpile.vfs import vfs, FilePath
 
 _plugins = PluginManager(builtin=__file__)
 
 
+def discover_piles(option_list, this_user, this_workdir):
+
+    # Extracts specified public options from accessible Mailpile configurations.
+
+    # Find Mailpile data directory for this user.
+    this_workdir_parent = os.path.abspath(this_workdir + '/..')
+    mp_data = [this_user, this_workdir_parent]
+    parent_list = [mp_data]
+    
+    # Use full path of this Mailpile's workdir as template
+    # to make parent_list - Mailpile data directories of 
+    # all users where permissions allow access to the workdirs.
+    #   Gnu-Linux permissions for other users to allow access:
+    #   mailpile.rc must have r, 
+    #   the workdir and all higher level directories must have x, but the
+    #   Mailpile data directory - parent of the workdirs - must have rx.
+    try:
+        index = this_workdir_parent.index(this_user)
+        workdir_head = this_workdir_parent[ 0:index ]
+        workdir_tail = this_workdir_parent[ index + len(this_user): ]
+        for user in os.listdir(workdir_head):
+            if user != this_user:
+                parent = workdir_head + user + workdir_tail
+                if os.path.isdir(parent):
+                    parent_list += [[user, parent]]
+    except OSError:
+        pass
+    
+    # Loop through accessible Mailpile data directories for all users.
+    pile_specs = []
+    for parent in parent_list:
+        try:
+            workdir_list = os.listdir(parent[1])
+        except OSError:
+            continue
+            
+        # Loop through all accessible Mailpile workdirs for one user.
+        for pile in workdir_list:
+            workdir = os.path.join(parent[1], pile)
+            if os.path.isdir(workdir):
+                public = ConfigParser.ConfigParser()
+                public_file = os.path.join(workdir, 'mailpile.rc')
+                
+                # If permissions allow, prevent mailpile.rc from being
+                # written by its owner while this process reads it.
+                lock_pub = fasteners.InterProcessLock(
+                                    os.path.join(workdir, 'public-lock'))
+                try:
+                    lock_pub.have = lock_pub.acquire(blocking=True, 
+                                                                timeout=5)
+                except IOError:
+                    lock_pub.have = False
+                
+                # Try to read mailpile.rc even if it could not be locked.
+                try:
+                    public.read(public_file)
+                except ConfigParser.Error:
+                    pass
+                    
+                if lock_pub.have:
+                   lock_pub.release()
+                
+                if not public.sections():
+                    continue               
+                
+                # Find all the option values for one pile.
+                specs = ()
+                for field in option_list:
+                    if not field[0]:
+                        if field[1] == 'user':
+                            specs += (parent[0],)
+                        elif field[1] == 'pile':
+                            specs += (pile,)
+                        else:
+                            specs += (' ',)
+                        continue
+                    for section in public.sections():
+                        # Find section name in commented section name.
+                        if section.startswith(field[0]):
+                            try:
+                                value = public.get(section,field[1])
+                                if isinstance(field[2],int):
+                                    value = int(value)
+                                specs += (value,)
+                            except (ConfigParser.NoOptionError, ValueError):
+                                specs += (field[2],)
+                            continue
+                pile_specs += [specs]
+                
+    return pile_specs
+    
+
+
 class Discover(Command):
     """Discover Mailpile piles present on this machine"""
-    SYNOPSIS = (None, 'discover', 'discover', "[-a] [-d] [</path/*.foo> ...]")
+    SYNOPSIS = (None, 'discover', None, "")
     ORDER = ('Internals', 5)
-    CONFIG_REQUIRED = True
+    CONFIG_REQUIRED = False
     IS_USER_ACTIVITY = True
     COMMAND_SECURITY = security.CC_BROWSE_FILESYSTEM
     
     # List of option values that are extracted for each pile.
-    # These are prefixed by the OS's user name and the pile name.
-    # If no value in config, the CONFIG_RULES default is used,
+    # These are prefixed by the OS's user name and the pile name
+    # which are handled as special cases in the code.
+    # If no value in config, the config.rules default is used,
     # failing that the value listed below.
     #    
-    #               Section                Option       Default
-    option_list_spec = [    ( 'config/sys:',       'http_host', 'localhost' ),
+    #                         Section              Option       Default
+    option_list_spec = [    ( '',                  'user',      ' '         ),
+                            ( '',                  'pile',      ' '         ),
+                            ( 'config/sys:',       'http_host', 'localhost' ),
                             ( 'config/sys:',       'http_port', 33411       ),
                             ( 'config/sys/proxy:', 'protocol',  'unknown'   ),
                             ( 'config/sys/proxy:', 'port',      8080        ) ]
                     
-    # Extract default values from mailpile.config.defaults.CONFIG_RULES
-    option_list = []
-    for option in option_list_spec:
-        # Split up section name, omit '/', omit ':', append option name.
-        subsec = option[0][:-1].split('/')[1:] + [option[1]]
-        value = mpdefaults.CONFIG_RULES
-        try:
-            while subsec:
-                value =  value[subsec[0]][2]
-                subsec = subsec[1:]
-            option = option[0:2] + (value,)
-        except (IndexError, KeyError):
-            pass
-        option_list += [option]
-        
-    def discover_piles(self, this_user, this_workdir):
-    
-        # Find Mailpile data directory for this user.
-        this_workdir_parent = os.path.abspath(this_workdir + '/..')
-        mp_data = [this_user, this_workdir_parent]
-        parent_list = [mp_data]
-        
-        # Use full path of this Mailpile's workdir as template
-        # to make parent_list - Mailpile data directories of 
-        # all users where permissions allow access to the workdirs.
-        #   Gnu-Linux permissions for other users to allow access:
-        #   mailpile.rc must have r, 
-        #   the workdir and all higher level directories must have x, but the
-        #   Mailpile data directory - parent of the workdirs - must have rx.
-        try:
-            index = this_workdir_parent.index(this_user)
-            workdir_head = this_workdir_parent[ 0:index ]
-            workdir_tail = this_workdir_parent[ index + len(this_user): ]
-            for user in os.listdir(workdir_head):
-                if user != this_user:
-                    parent = workdir_head + user + workdir_tail
-                    if os.path.isdir(parent):
-                        parent_list += [[user, parent]]
-        except OSError:
-            pass
-        
-        # Loop through accessible Mailpile data directories for all users.
-        pile_specs = []
-        for parent in parent_list:
-            try:
-                workdir_list = os.listdir(parent[1])
-            except OSError:
-                continue
-                
-            # Loop through all accessible Mailpile workdirs for one user.
-            for pile in workdir_list:
-                workdir = os.path.join(parent[1], pile)
-                if os.path.isdir(workdir):
-                    public = ConfigParser.ConfigParser()
-                    public_file = os.path.join(workdir, 'mailpile.rc')
-                    
-                    # If permissions allow, prevent mailpile.rc from being
-                    # written by its owner while this process reads it.
-                    lock_pub = fasteners.InterProcessLock(
-                                        os.path.join(workdir, 'public-lock'))
-                    try:
-                        lock_pub.have = lock_pub.acquire(blocking=True, 
-                                                                    timeout=5)
-                    except IOError:
-                        lock_pub.have = False
-                    
-                    # Try to read mailpile.rc even if it could not be locked.
-                    try:
-                        public.read(public_file)
-                    except ConfigParser.Error:
-                        pass
-                        
-                    if lock_pub.have:
-                       lock_pub.release()
-                    
-                    if not public.sections():
-                        continue               
-                    
-                    # Find all the option values for one pile.
-                    specs = (parent[0], pile)
-                    for field in self.option_list:
-                        for section in public.sections():
-                            # Find section name in commented section name.
-                            if section.startswith(field[0]):
-                                try:
-                                    value = public.get(section,field[1])
-                                    if isinstance(field[2],int):
-                                        value = int(value)
-                                    specs += (value,)
-                                except (ConfigParser.NoOptionError, ValueError):
-                                    specs += (field[2],)
-                                continue
-                    pile_specs += [specs]
-                    
-        return pile_specs
-
     class CommandResult(Command.CommandResult):
         def as_text(self):
+            lines = []
             if self.result:
-                lines = []
                 lines.append(('%-15s %-15s %-15s %-5s   %-15s %-5s') % ('User',
                         'Pile', 'Host', 'Port', 'Proxy-protocol', '-port'))
                 lines.append('')              
@@ -177,11 +174,29 @@ class Discover(Command):
     def command(self, args=None):
     
         config = self.session.config
-
+       
         this_workdir = config.workdir
         this_user = getpass.getuser()
         
-        pile_specs = self.discover_piles(this_user, this_workdir)
+        # Extract default values from config.rules
+        option_list = []
+        for option in self.option_list_spec:
+            if not option[0]:
+                option_list += [option]
+                continue
+            # Split up section name, omit '/', omit ':', append option name.
+            subsec = option[0][:-1].split('/')[1:] + [option[1]]
+            value = config.rules
+            try:
+                while subsec:
+                    value =  value[subsec[0]][2]
+                    subsec = subsec[1:]
+                option = option[0:2] + (value,)
+            except (IndexError, KeyError):
+                pass
+            option_list += [option]
+            
+        pile_specs = discover_piles(option_list, this_user, this_workdir)
 
         return self._success(_('Listed %d piles') % len(pile_specs),
                                                             result=pile_specs)

--- a/mailpile/plugins/discover.py
+++ b/mailpile/plugins/discover.py
@@ -1,0 +1,189 @@
+# This code searches a computer for Mailpile pile directories
+# and prints a summary of their location and associated ports.
+# 
+# Copyright (C) 2018 Jack Dodds
+# This code is part of Mailpile and is hereby released under the
+# Gnu Affero Public Licence v.3 - see ../../COPYING and ../../AGPLv3.txt.
+#
+
+import os
+import sys
+import getpass
+import ConfigParser
+import fasteners
+import mailpile.config.defaults as mpdefaults
+
+
+import datetime
+import json
+import random
+import re
+import socket
+import subprocess
+import traceback
+import threading
+import time
+import webbrowser
+
+import mailpile.util
+import mailpile.postinglist
+import mailpile.security as security
+from mailpile.commands import *
+from mailpile.config.validators import WebRootCheck
+from mailpile.crypto.gpgi import GnuPG
+from mailpile.eventlog import Event
+from mailpile.i18n import gettext as _
+from mailpile.i18n import ngettext as _n
+from mailpile.mailboxes import IsMailbox
+from mailpile.mailutils import ClearParseCache, Email
+from mailpile.postinglist import GlobalPostingList
+from mailpile.plugins import PluginManager
+from mailpile.safe_popen import MakePopenUnsafe, MakePopenSafe
+from mailpile.search import MailIndex
+from mailpile.util import *
+from mailpile.vcard import AddressInfo
+from mailpile.vfs import vfs, FilePath
+
+_plugins = PluginManager(builtin=__file__)
+
+
+class Discover(Command):
+    """Discover Mailpile piles present on this machine"""
+    SYNOPSIS = (None, 'discover', 'discover', "[-a] [-d] [</path/*.foo> ...]")
+    ORDER = ('Internals', 5)
+    CONFIG_REQUIRED = True
+    IS_USER_ACTIVITY = True
+    COMMAND_SECURITY = security.CC_BROWSE_FILESYSTEM
+    
+    # List of option values that are extracted for each pile.
+    # These are prefixed by the OS's user name and the pile name.
+    # If no value in config, the CONFIG_RULES default is used,
+    # failing that the value listed below.
+    #    
+    #               Section                Option       Default
+    option_list_spec = [    ( 'config/sys:',       'http_host', 'localhost' ),
+                            ( 'config/sys:',       'http_port', 33411       ),
+                            ( 'config/sys/proxy:', 'protocol',  'unknown'   ),
+                            ( 'config/sys/proxy:', 'port',      8080        ) ]
+                    
+    # Extract default values from mailpile.config.defaults.CONFIG_RULES
+    option_list = []
+    for option in option_list_spec:
+        # Split up section name, omit '/', omit ':', append option name.
+        subsec = option[0][:-1].split('/')[1:] + [option[1]]
+        value = mpdefaults.CONFIG_RULES
+        try:
+            while subsec:
+                value =  value[subsec[0]][2]
+                subsec = subsec[1:]
+            option = option[0:2] + (value,)
+        except (IndexError, KeyError):
+            pass
+        option_list += [option]
+        
+    def discover_piles(self, this_user, this_workdir):
+    
+        # Find Mailpile data directory for this user.
+        this_workdir_parent = os.path.abspath(this_workdir + '/..')
+        mp_data = [this_user, this_workdir_parent]
+        parent_list = [mp_data]
+        
+        # Use full path of this Mailpile's workdir as template
+        # to make parent_list - Mailpile data directories of 
+        # all users where permissions allow access to the workdirs.
+        #   Gnu-Linux permissions for other users to allow access:
+        #   mailpile.rc must have r, 
+        #   the workdir and all higher level directories must have x, but the
+        #   Mailpile data directory - parent of the workdirs - must have rx.
+        try:
+            index = this_workdir_parent.index(this_user)
+            workdir_head = this_workdir_parent[ 0:index ]
+            workdir_tail = this_workdir_parent[ index + len(this_user): ]
+            for user in os.listdir(workdir_head):
+                if user != this_user:
+                    parent = workdir_head + user + workdir_tail
+                    if os.path.isdir(parent):
+                        parent_list += [[user, parent]]
+        except OSError:
+            pass
+        
+        # Loop through accessible Mailpile data directories for all users.
+        pile_specs = []
+        for parent in parent_list:
+            try:
+                workdir_list = os.listdir(parent[1])
+            except OSError:
+                continue
+                
+            # Loop through all accessible Mailpile workdirs for one user.
+            for pile in workdir_list:
+                workdir = os.path.join(parent[1], pile)
+                if os.path.isdir(workdir):
+                    public = ConfigParser.ConfigParser()
+                    public_file = os.path.join(workdir, 'mailpile.rc')
+                    
+                    # If permissions allow, prevent mailpile.rc from being
+                    # written by its owner while this process reads it.
+                    lock_pub = fasteners.InterProcessLock(
+                                        os.path.join(workdir, 'public-lock'))
+                    try:
+                        lock_pub.have = lock_pub.acquire(blocking=True, 
+                                                                    timeout=5)
+                    except IOError:
+                        lock_pub.have = False
+                    
+                    # Try to read mailpile.rc even if it could not be locked.
+                    try:
+                        public.read(public_file)
+                    except ConfigParser.Error:
+                        pass
+                        
+                    if lock_pub.have:
+                       lock_pub.release()
+                    
+                    if not public.sections():
+                        continue               
+                    
+                    # Find all the option values for one pile.
+                    specs = (parent[0], pile)
+                    for field in self.option_list:
+                        for section in public.sections():
+                            # Find section name in commented section name.
+                            if section.startswith(field[0]):
+                                try:
+                                    value = public.get(section,field[1])
+                                    if isinstance(field[2],int):
+                                        value = int(value)
+                                    specs += (value,)
+                                except (ConfigParser.NoOptionError, ValueError):
+                                    specs += (field[2],)
+                                continue
+                    pile_specs += [specs]
+                    
+        return pile_specs
+
+    class CommandResult(Command.CommandResult):
+        def as_text(self):
+            if self.result:
+                lines = []
+                lines.append(('%-15s %-15s %-15s %-5s   %-15s %-5s') % ('User',
+                        'Pile', 'Host', 'Port', 'Proxy-protocol', '-port'))
+                lines.append('')              
+                for i in self.result:
+                    lines.append(('%-15s %-15s %-15s %-5d   %-15s %-5d') % i)
+        
+            return '\n'.join(lines)
+
+    def command(self, args=None):
+    
+        config = self.session.config
+
+        this_workdir = config.workdir
+        this_user = getpass.getuser()
+        
+        pile_specs = self.discover_piles(this_user, this_workdir)
+
+        return self._success(_('Listed %d piles') % len(pile_specs),
+                                                            result=pile_specs)
+
+_plugins.register_commands(Discover)

--- a/scripts/mailpile
+++ b/scripts/mailpile
@@ -8,7 +8,8 @@ mailpile_root = os.path.dirname(     # Mailpile root
     )
 )
 
-sys.path.append(mailpile_root)
+# sys.path.append(mailpile_root) # *** DEBUG - coexist with deb installed MP
+sys.path = [mailpile_root] + sys.path
 
 from mailpile.app import Main
 Main(sys.argv[1:])


### PR DESCRIPTION
This PR attempts to address some of the issues identified in #877.

- It adds random port selection to the www command, invoked by specifying port number 0. New public parameters http_port_min and http_port_max put limits on the new port number. The discover command code (if available - see below) is used to check against a list of port numbers already in use by other piles (where permissions allow) and the port is also checked to see that no process is actively listening on it.
- It provides a "discover" command. This uses the full path to the data directory (workdir) of the present Mailpile as a template, and checks for other piles belonging to the present user and other users (where permissions allow). Parameters are provided to limit the search to specific user(s) or pile names(s). The result is a table of configuration parameters extracted from mailpile.rc files.
- The term "profile" was being used in two different ways in manager.py: to mean all the configuration parameters associated with one receiving email address; and, to mean all user data accessible to one Mailpile instance (as in environment variable MAILPILE_PROFILE). The first meaning was used extensively in the UI and in the configuration file, so in the code the term "pile" was used to replace the term "profile" where the second meaning was intended. Variables called "pile" are used for the base name (last component) of the data directory path. Consistent with this, a new environment variable MAILPILE_PILENAME is checked and takes priority over MAILPILE_PROFILE.

The www random port selection can be used to create a new pile on a random port or to access an existing pile on a random port on every launch (#877 option 1)

	export MAILPILE_PILENAME=alicemail ; ./mp --www localhost:0 --interact

Once a pile is set up, it can also be accessed without changing the port number from the one used at setup (#877 option 2):

	export MAILPILE_PILENAME=alicemail ; ./mp

The user can also get a list of piles on the machine. At present Mailpile's default permissions only allow access to piles belonging to the same user but the command will look for everything that is accessible:

	./mp discover

or with optional parameters it can be limited to specific users and/or pile names:

	./mp discover --user=alice,bob --pile=default,alicemail


Comments:

- It would be good to allow launching of the web browser to access an already running Mailpile. When Mailpile is not at the default port location the user may not know the port. Unfortunately browse_or_launch is broken at present (#1993) so this doesn't work:

	export MAILPILE_PILENAME=alicemail ; ./mp browse_or_launch

- Comments would be appreciated on the format of the argument list for discover. There seem to be several possibilites (leading -- on command? -- on options? use = or two seperate strings?).

- Should authentication be required before discover can be used?

All the above is presented for discussion. Any and all comments are welcome
