### PR TITLE
Fix memory leak in autoajax caused by extraneous whitespace

### DIFF
--- a/shared-data/contrib/autoajax/autoajax.js
+++ b/shared-data/contrib/autoajax/autoajax.js
@@ -252,7 +252,7 @@ refresh_from_cache = function(cid) {
                  var cid = json.state.cache_id;
                  if (can_refresh(cid)) {
                      var selected = get_selection_state();
-                     $('.content-'+cid).replaceWith(json.result);
+                     $('.content-'+cid).replaceWith(json.result.trim());
                      Mailpile.UI.prepare_new_content('.content-'+cid);
                      restore_selection_state(selected);
                      refresh_history[cid] = get_now();


### PR DESCRIPTION
This leak is identical in nature to #1931, and was automatically found by [BLeak](https://github.com/plasma-umass/bleak) while running it on Mailpile again.