### PR TITLE
Fix for issue #1566 - garbarge search results on unclean shutdown

### DIFF
--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -195,7 +195,19 @@ class MailIndex(BaseIndex):
                                len(self.INDEX)
                                ) % len(self.INDEX))
         self.EMAILS_SAVED = len(self.EMAILS)
-
+        
+        # Make sure metadata index has entry for every msg_mid in keyword index.
+        max_kw_msg_idx_pos = GlobalPostingList.GetMaxMsgIdxPos()
+        
+        if max_kw_msg_idx_pos > len(self.INDEX) - 1:
+            if session:
+                session.ui.warning(_(
+                    'Fixing %d messages in keyword index not in metadata.'
+                                 ) % (max_kw_msg_idx_pos + 1 - len(self.INDEX)))
+            
+            for msg_idx_pos in range(len(self.INDEX), max_kw_msg_idx_pos + 1):
+                self.add_new_ghost(b36(msg_idx_pos))
+                
     def update_msg_tags(self, msg_idx_pos, msg_info):
         tags = set(self.get_tags(msg_info=msg_info))
         with self._lock:
@@ -1352,6 +1364,8 @@ class MailIndex(BaseIndex):
             except UnicodeDecodeError:
                 # FIXME: we just ignore garbage
                 pass
+                
+        GlobalPostingList.UpdateMaxMsgMid(session, [msg_mid])        
 
         self.config.command_cache.mark_dirty(set([u'mail:all']) | keywords)
         return keywords, snippet


### PR DESCRIPTION
This fix follows roughly the approach proposed in #1566.

- Create special key '1' in GPL to hold max MSG_MID in GPL.
- Update value for key '1' whenever GPL is updated.
- Check metadata index against GPL '1' value at startup,
    add ghost entries for missing MSG_MIDs.
- Block migration of GPL '1' to PostingListContainer.

The maximum MSG_MID is maintained under a "special key" '1' in the GPL. This avoids the possibility that all copies of the maximum MSG_MID might be migrated to PostingListContainers which would make the result of scanning the GPL incorrect. (This may never happen in practice but it was not obvious from studying the code that it was impossible.) Also the "special key" approach requires less number crunching. Comparing those variable length base36 values is annoying.

The code has been tested by killing Mailpile during the download of about 200 emails, then restarting. Searches were done using the web UI, and mailpile.idx was decrypted and examined. It appears to work. There's no special code needed to migrate from earlier versions. The first time that a new email is indexed with this code, key '1' will be created and immediately saved (appended) to kw-journal.dat.

However, the deleted metadata index entries still appear with the subject "(missing message)" unless they are filtered out, e.g. by adding the search term "in:inbox". Perhaps "ghost" entries should be filtered out of all search results.