### PR TITLE
Recipients email ID

### DIFF
--- a/shared-data/default-theme/html/jsapi/compose/recipients.js
+++ b/shared-data/default-theme/html/jsapi/compose/recipients.js
@@ -175,14 +175,20 @@ Mailpile.Composer.Recipients.AddressField = function(id) {
       if (state.photo) {
         avatar = '<span class="avatar"><img src="' + _.escape(state.photo) + '" data-address="' + state.address + '"></span>';
       }
+
       if (!state.fn) {
         name = state.address;
       }
+
       if (state.flags.secure) {
         secure = '<span class="icon-lock-closed" data-address="' + _.escape(state.address) + '"></span>';
       }
 
+      if (!state.fn){
+      return avatar + ' <span class="compose-choice-name" data-address="' + _.escape(state.address) + '">' + _.escape(state.address) + secure + '</span>';
+      } else {
       return avatar + ' <span class="compose-choice-name" data-address="' + _.escape(state.address) + '">' + _.escape(name) + secure + '</span>';
+      }
     },
     formatSelectionTooBig: function() {
       return 'You\'ve added the maximum contacts allowed, to increase this go to <a href="#">settings</a>';

--- a/shared-data/default-theme/html/partials/search_item.html
+++ b/shared-data/default-theme/html/partials/search_item.html
@@ -130,6 +130,7 @@
   {%- if thread|length > 1 %}
     {%- include "partials/pile_threading.html" %}
   {%- endif %}
+  </td>
 {% else %}
   <td class="avatar">
     <a><img src="{{ show_avatar(from) }}"></a>
@@ -150,6 +151,7 @@
       {%- if to1.fn %}{{ to1.fn|nice_name(28) }}{% else %}(&lt;{{ to1.address }}&gt;){% endif %}
       {% if to_cc|length > 1 %}<span class="rcpt-count">+{{ to_cc|length -1 }}</span>{% endif %}
     </a>
+  </td>
  {%- else %}
   <td class="from people">
     <a href="{{msg_url(mid)}}" data-noblank=1 data-keep-selection=1
@@ -228,6 +230,7 @@
             {%- elif elem.icon -%}
             <span class="navigation-icon icon-{{elem.icon}}"></span>
             {%- endif %}
+          </a>
           </li>
           {%- endfor %}
           <li><a title="{{ _('Switch to full conversation view') }}"

--- a/shared-data/default-theme/html/partials/search_item.html
+++ b/shared-data/default-theme/html/partials/search_item.html
@@ -130,7 +130,6 @@
   {%- if thread|length > 1 %}
     {%- include "partials/pile_threading.html" %}
   {%- endif %}
-  </td>
 {% else %}
   <td class="avatar">
     <a><img src="{{ show_avatar(from) }}"></a>
@@ -151,7 +150,6 @@
       {%- if to1.fn %}{{ to1.fn|nice_name(28) }}{% else %}(&lt;{{ to1.address }}&gt;){% endif %}
       {% if to_cc|length > 1 %}<span class="rcpt-count">+{{ to_cc|length -1 }}</span>{% endif %}
     </a>
-  </td>
  {%- else %}
   <td class="from people">
     <a href="{{msg_url(mid)}}" data-noblank=1 data-keep-selection=1
@@ -230,7 +228,6 @@
             {%- elif elem.icon -%}
             <span class="navigation-icon icon-{{elem.icon}}"></span>
             {%- endif %}
-          </a>
           </li>
           {%- endfor %}
           <li><a title="{{ _('Switch to full conversation view') }}"


### PR DESCRIPTION
This PR attempts to resolve the issue #2027 

- This intends towards a better user experience wherein when an email is being composed, if the recipient is already a contact, the name of the contact is displayed, but if the recipient's email id isn't a contact for the account of the user, the entire email id will be displayed.

- Also, while digging deep and checking for other places wherein this might require an edit, I found some unclosed tags in search_item.html.