### PR TITLE
Add a setting to configure AJAX request timeout

### DIFF
--- a/mailpile/config/defaults.py
+++ b/mailpile/config/defaults.py
@@ -39,6 +39,7 @@ CONFIG_RULES = {
         'http_port':     p(_('Listening port for web UI'), int,         33411),
         'http_path':     p(_('HTTP path of web UI'), 'webroot',            ''),
         'http_no_auth':  X(_('Disable HTTP authentication'),      bool, False),
+        'ajax_timeout':  p(_('AJAX Request timeout'), int,              10000),
         'postinglist_kb': (_('Posting list target size in KB'), int,       64),
         'sort_max':       (_('Max results we sort "well"'), int,         2500),
         'snippet_max':    (_('Max length of metadata snippets'), int,     275),

--- a/shared-data/contrib/autoajax/autoajax.js
+++ b/shared-data/contrib/autoajax/autoajax.js
@@ -221,7 +221,7 @@ update_using_jhtml = function(original_url, callback, error_callback,
                                  document.title);
         return $.ajax({
             url: Mailpile.API.jhtml_url(original_url, 'content'),
-            timeout: Mailpile.ajax_timeout
+            timeout: Mailpile.ajax_timeout,
             type: 'GET',
             success: function(data) {
                 if (!nohistory)

--- a/shared-data/contrib/autoajax/autoajax.js
+++ b/shared-data/contrib/autoajax/autoajax.js
@@ -221,6 +221,7 @@ update_using_jhtml = function(original_url, callback, error_callback,
                                  document.title);
         return $.ajax({
             url: Mailpile.API.jhtml_url(original_url, 'content'),
+            timeout: Mailpile.ajax_timeout
             type: 'GET',
             success: function(data) {
                 if (!nohistory)

--- a/shared-data/default-theme/html/jsapi/global/eventlog.js
+++ b/shared-data/default-theme/html/jsapi/global/eventlog.js
@@ -65,7 +65,7 @@ EventLog.poll = function() {
     since: EventLog.last_ts,
     gather: (EventLog.last_ts < 0) ? 0.2 : 1.0,
     wait: 30,
-    _timeout: 31000
+    _timeout: (Mailpile.ajax_timeout * 3)
   });
 };
 

--- a/shared-data/default-theme/html/jsapi/index.js
+++ b/shared-data/default-theme/html/jsapi/index.js
@@ -100,6 +100,7 @@ Mailpile = {
     }
   ],
   nagify: 1000 * 60 * 60 * 24 * 7, // Default nag is 1 per week
+  ajax_timeout: {{config.sys.ajax_timeout}},
   commands:      [],
   graphselected: [],
   defaults: {
@@ -249,7 +250,7 @@ Mailpile.API = {
   _action: function(base_url, command, data, method, callback) {
     // Output format, timeout...
     var output = '';
-    var timeout = 10000;
+    var timeout = Mailpile.ajax_timeout;
     var error_callback = undefined;
     if (data._output) {
       output = data._output;

--- a/shared-data/default-theme/html/profiles/account-form.html
+++ b/shared-data/default-theme/html/profiles/account-form.html
@@ -159,7 +159,7 @@
             });
             Mailpile.API.setup_email_servers_get({
               'track-id': new_src_id,
-              '_timeout': 300000, // AJAX timeout
+              '_timeout': (Mailpile.ajax_timeout * 30), // AJAX timeout
               'timeout': 240000,  // Server-side deadline
               'email': email,
               '_error_callback': function(response, _status) {

--- a/shared-data/default-theme/html/settings/privacy.html
+++ b/shared-data/default-theme/html/settings/privacy.html
@@ -145,7 +145,7 @@
             $('#enable-tor-working').show();
             $('#enable-tor-result').html('');
             Mailpile.API.setup_tor_post({
-              _timeout: 300000
+              _timeout: (Mailpile.ajax_timeout * 30)
             }, function(result) {
               $('#enable-tor-working').hide();
               $('#enable-tor').show();


### PR DESCRIPTION
Here is my initial stab at a configurable AJAX request timeout. It seems to be working pretty well for me in testing. Let me know if you see any issues.

The one change that could create issues is adding a timeout to the autoajax.js request. I'm not sure what the default timeout is when none is specified. From a quick search, it seems like the default is no timeout at all. So, adding one maybe cause requests that used to work before to fail now.

Fixes #2050.