### PR TITLE
Printing a warning if the app is unconfigured.

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -16,6 +16,7 @@ from mailpile.plugins import PluginManager
 from mailpile.plugins.core import Help, HelpSplash, HealthCheck
 from mailpile.plugins.core import Load, Rescan, Quit
 from mailpile.plugins.motd import MessageOfTheDay
+from mailpile.plugins.setup_magic import Setup
 from mailpile.ui import ANSIColors, Session, UserInteraction, Completer
 from mailpile.util import *
 
@@ -108,6 +109,8 @@ def Interact(session):
             try:
                 with session.ui.term:
                     session.ui.block()
+                    if Setup.Next(session.config, 'anything') != 'anything':
+                        session.ui.notify('The app is unconfigured, please run setup or visit the web UI.')
                     opt = threaded_raw_input(prompt)
             except KeyboardInterrupt:
                 session.ui.unblock(force=True)


### PR DESCRIPTION
Hi, I've looked at issue #2025 .
As requested, a warning is printed before each call to `threaded_raw_input()`, if the app is unconfigured.