### PR TITLE
Dragging and dropping tags hint

### DIFF
--- a/shared-data/contrib/hints/hints.py
+++ b/shared-data/contrib/hints/hints.py
@@ -73,6 +73,12 @@ class hintsCommand(Command):
 	    _('Rearrange your sidebar to organize how you see your e-mail'),
 	    '/page/hints/organize-sidebar.html'),
 
+        # Show the user how dragging and dropping tags or messages works
+        # after 7 days.
+        ('dragging', 7, 365,
+            _('Learn how dragging and dropping tags works.'),
+            '/page/hints/dragging-tags.html'),
+
         # Introduce Gravatar integration after 10 days, and yearly repetition.
         # Remind of the privacy implications
         ('gravatar', 10, 365,

--- a/shared-data/contrib/hints/hints/dragging-tags.html
+++ b/shared-data/contrib/hints/hints/dragging-tags.html
@@ -1,0 +1,24 @@
+{% extends "layouts/" + render_mode + "-tall.html" %}
+{% block title %}{{_("Dragging and dropping tags")}}{% endblock %}
+{% block content %}
+<div class="content-normal" style="max-width: 46em;">
+
+  <h1><span class="icon-tag"></span>
+    {{_("Dragging and dropping tags")}}
+  </h1>
+  <p>
+  	{{_("You can drag and drop tags or messages to add or change tags.")}}<br>
+  	{{_("The rules are following:")}}
+  </p>
+  <ul class="list" style="margin-left: 2em; list-style: disc;">
+  	<li>{{_("If you drag a message from a search result view onto a tag, all tags from the message are removed and the tag you drop the message on is added.")}}</li>
+  	<li>{{_("if you drag a tag from the sidebar onto a message, the tag is added to the message and other existing tags are not removed.")}}</li>
+  </ul>
+  <p>{{_("For example:")}}<br></p>
+  <ul class="list" style="margin-left: 2em; list-style: disc;">
+  	<li>{{_("If you're looking at the search 'in:inbox in:job', which is the intersection of messages in both Inbox and Job, dragging a message onto the Trash tag will remove both Inbox and Job tags and add the Trash tag.")}}</li>
+  	<li>{{_("If you're looking at the search 'in:inbox', dragging a School tag from the sidebar to a message will add the School tag to the message and the Inbox tag is not removed.")}}</li>
+  </ul>
+
+</div>
+{% endblock %}

--- a/shared-data/contrib/hints/manifest.json
+++ b/shared-data/contrib/hints/manifest.json
@@ -19,7 +19,8 @@
         "/page/hints/spam.html": {"file": "hints/spam.html"},
         "/page/hints/spambayes.html": {"file": "hints/spambayes.html"},
         "/page/hints/keyboard-shortcuts.html": {"file": "hints/keyboard-shortcuts.html"},
-        "/page/hints/autotagging.html": {"file": "hints/autotagging.html"}
+        "/page/hints/autotagging.html": {"file": "hints/autotagging.html"},
+        "/page/hints/dragging-tags.html": {"file": "hints/dragging-tags.html"}
     },
     "user_interface": {
         "activities": [


### PR DESCRIPTION
I added a hint about dragging and dropping tags and messages (issue #1873).