### PR TITLE
Import the win_inet_pton library.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,19 @@ before filing issues about design choices or attempting to reorganize the code
 in any major way. The FAQ also contains a quick introduction Mailpile internals
 and debugging techniques.
 
+Also, have you seen [the main Mailpile website](https://www.mailpile.is/)?
+
+
+#### Are you new to Mailpile and/or FOSS?
+
+* Welcome! The first step is probably to get Mailpile up and running, play with it, get familiar.
+
+* Read the links above, and [check out our website](https://www.mailpile.is/) if you haven't already.
+
+* Not sure what to work on? Find inspiration in one of our [Low Hanging Fruit](https://github.com/mailpile/Mailpile/issues?q=is%3Aissue+is%3Aopen+label%3A%22Low+Hanging+Fruit%22) issues!
+
+* Otherwise, read on...
+
 
 #### Did you find a bug?
 
@@ -47,7 +60,7 @@ and debugging techniques.
 * The [Developer FAQ](DEV_FAQ.md) has a section on debugging techniques.
 
 
-#### **Did you write a patch that fixes a bug?**
+#### Did you write a patch that fixes a bug?
 
 * Open a new GitHub pull request with the patch.
 
@@ -55,7 +68,7 @@ and debugging techniques.
   Include the relevant issue number if applicable.
 
 
-#### **Do you plan write a patch that adds a feature?**
+#### Do you plan write a patch that adds a feature?
 
 * Please be sure you have read the [Developer FAQ](DEV_FAQ.md) to ensure
   your feature is compatible with our high-level goals and design decisions.
@@ -69,7 +82,7 @@ and debugging techniques.
   Include the relevant issue number if applicable.
 
 
-#### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
+#### Did you fix whitespace, format code, or make a purely cosmetic patch?
 
 Changes that are cosmetic in nature and do not add anything substantial to the
 stability, functionality, or testability of Mailpile will generally not be
@@ -81,13 +94,13 @@ patches and we would rather focus our efforts on functional improvements to the
 software.
 
 
-#### **Do you want to translate Mailpile to your language?**
+#### Do you want to translate Mailpile to your language?
 
 Please feel free to join our translation community
 [on Transifex](https://www.transifex.com/otf/mailpile/).
 
 
-#### **Do you plan to write documentation?**
+#### Do you plan to write documentation?
 
 * Please feel free to contribute documentation to
   [our wiki](https://github.com/mailpile/Mailpile/wiki).

--- a/mailpile/config/validators.py
+++ b/mailpile/config/validators.py
@@ -2,6 +2,7 @@ import os
 import socket
 import re
 
+import win_inet_pton
 from urlparse import urlparse
 
 from mailpile.i18n import gettext as _

--- a/mailpile/config/validators.py
+++ b/mailpile/config/validators.py
@@ -2,7 +2,11 @@ import os
 import socket
 import re
 
-import win_inet_pton
+try:
+    import win_inet_pton
+except:
+    pass
+
 from urlparse import urlparse
 
 from mailpile.i18n import gettext as _

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ pgpdump
 pillow
 pbr
 fasteners
+win_inet_pton

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,4 +15,4 @@ pgpdump
 pillow
 pbr
 fasteners
-win_inet_pton
+win_inet_pton; sys_platform == 'win32'


### PR DESCRIPTION
On windows socket.inet_pton is not available. This causes a testcase to fail.
Importing the win_inet_pton library is sufficient to pass the test.