### PR TITLE
Replace master_key with get_master_key. Fixes #1900

### DIFF
--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -365,8 +365,7 @@ class ConfigManager(ConfigDict):
 
         if keydata:
             self.passphrases['DEFAULT'].copy(passphrase)
-            # Prefix each key with a unique character to prevent optimization
-            self._master_key = [i + ''.join(keydata) for i in ('1', '2', '3')]
+            self.set_master_key(''.join(keydata))
             self._master_key_ondisk = self.get_master_key()
             self._master_key_passgen = self.passphrases['DEFAULT'].generation
             return True
@@ -535,9 +534,12 @@ class ConfigManager(ConfigDict):
             key = self._master_key[1][1:]
         else:
             raise _raise("Failed to access master_key")
+        self.set_master_key(key)
+        return key
+
+    def set_master_key(self, key):
         # Prefix each key with a unique character to prevent optimization
         self._master_key = [i + key for i in ('1', '2', '3')]
-        return key
 
     def _delete_old_master_keys(self, keyfile):
         """

--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -365,8 +365,8 @@ class ConfigManager(ConfigDict):
 
         if keydata:
             self.passphrases['DEFAULT'].copy(passphrase)
-            self.master_key = ''.join(keydata)
-            self._master_key_ondisk = self.master_key
+            self._master_key = [''.join(keydata)]
+            self._master_key_ondisk = self.get_master_key()
             self._master_key_passgen = self.passphrases['DEFAULT'].generation
             return True
         else:
@@ -475,9 +475,9 @@ class ConfigManager(ConfigDict):
         ## both config files!
 
         # Open event log
-        dec_key_func = lambda: self.master_key
+        dec_key_func = lambda: self.get_master_key()
         enc_key_func = lambda: (self.prefs.encrypt_events and
-                                self.master_key)
+                                self.get_master_key())
         self.event_log = EventLog(self.data_directory('event_log',
                                                       mode='rw', mkdir=True),
                                   dec_key_func, enc_key_func
@@ -527,6 +527,16 @@ class ConfigManager(ConfigDict):
         with self._lock:
             self._unlocked_save(*args, **kwargs)
 
+    def get_master_key(self):
+        if self._master_key[0] in self._master_key[1:]:
+            key = self._master_key[0]
+        elif self._master_key[1] in [self._master_key[0], self._master_key[2]]:
+            key = self._master_key[1]
+        else:
+            raise _raise("Failed to access master_key")
+        self._master_key = [key]*3
+        return key
+
     def _delete_old_master_keys(self, keyfile):
         """
         We keep old master key files around for up to 5 days, so users can
@@ -542,14 +552,14 @@ class ConfigManager(ConfigDict):
                 safe_remove(fn)
 
     def _save_master_key(self, keyfile):
-        if not self.master_key:
+        if not self.get_master_key():
             return False
 
         # We keep the master key in a file of its own...
         want_renamed_keyfile = None
         master_passphrase = self.passphrases['DEFAULT']
         if (self._master_key_passgen != master_passphrase.generation
-                or self._master_key_ondisk != self.master_key):
+                or self._master_key_ondisk != self.get_master_key()):
             if os.path.exists(keyfile):
                 want_renamed_keyfile = keyfile + ('.%x' % time.time())
 
@@ -578,7 +588,7 @@ class ConfigManager(ConfigDict):
         # FIXME: Create event and capture GnuPG state?
         mps = master_passphrase.stretched(salt)
         gpg = GnuPG(self, passphrase=mps)
-        status, encrypted_key = gpg.encrypt(self.master_key, tokeys=tokeys)
+        status, encrypted_key = gpg.encrypt(self.get_master_key(), tokeys=tokeys)
         if status == 0:
             if salt:
                 h, b = encrypted_key.replace('\r', '').split('\n\n', 1)
@@ -590,7 +600,7 @@ class ConfigManager(ConfigDict):
                 if want_renamed_keyfile:
                     os.rename(keyfile, want_renamed_keyfile)
                 os.rename(keyfile + '.new', keyfile)
-                self._master_key_ondisk = self.master_key
+                self._master_key_ondisk = self.get_master_key()
                 self._master_key_passgen = master_passphrase.generation
 
                 # Delete any old key backups we have laying around
@@ -652,9 +662,9 @@ class ConfigManager(ConfigDict):
                          for i in range(0, len(config_bytes), 4096))
 
         from mailpile.crypto.streamer import EncryptingStreamer
-        if self.master_key and master_key_saved:
+        if self.get_master_key() and master_key_saved:
             subj = self.mailpile_path(self.conffile)
-            with EncryptingStreamer(self.master_key,
+            with EncryptingStreamer(self.get_master_key(),
                                     dir=self.tempfile_dir(),
                                     header_data={'subject': subj},
                                     name='Config') as fd:
@@ -766,10 +776,10 @@ class ConfigManager(ConfigDict):
 
     def load_pickle(self, pfn):
         with open(os.path.join(self.workdir, pfn), 'rb') as fd:
-            if self.master_key:
+            if self.get_master_key():
                 from mailpile.crypto.streamer import DecryptingStreamer
                 with DecryptingStreamer(fd,
-                                        mep_key=self.master_key,
+                                        mep_key=self.get_master_key(),
                                         name='load_pickle(%s)' % pfn
                                         ) as streamer:
                     rv = cPickle.loads(streamer.read())
@@ -780,9 +790,9 @@ class ConfigManager(ConfigDict):
 
     def save_pickle(self, obj, pfn, encrypt=True):
         ppath = os.path.join(self.workdir, pfn)
-        if encrypt and self.master_key and self.prefs.encrypt_misc:
+        if encrypt and self.get_master_key() and self.prefs.encrypt_misc:
             from mailpile.crypto.streamer import EncryptingStreamer
-            with EncryptingStreamer(self.master_key,
+            with EncryptingStreamer(self.get_master_key(),
                                     dir=self.tempfile_dir(),
                                     header_data={'subject': pfn},
                                     name='save_pickle') as fd:
@@ -1007,9 +1017,9 @@ class ConfigManager(ConfigDict):
             mbox.is_local = prefer_local
 
         # Always set these, they can't be pickled
-        mbox._decryption_key_func = lambda: self.master_key
+        mbox._decryption_key_func = lambda: self.get_master_key()
         mbox._encryption_key_func = lambda: (self.prefs.encrypt_mail and
-                                             self.master_key)
+                                             self.get_master_key())
 
         # Finally, re-add to the cache
         self.cache_mailbox(session, pfn, mbx_id, mbox)
@@ -1032,9 +1042,9 @@ class ConfigManager(ConfigDict):
                     path = os.path.join(path, os.path.basename(name))
 
             mbx = wervd.MailpileMailbox(path)
-            mbx._decryption_key_func = lambda: self.master_key
+            mbx._decryption_key_func = lambda: self.get_master_key()
             mbx._encryption_key_func = lambda: (self.prefs.encrypt_mail and
-                                                self.master_key)
+                                                self.get_master_key())
             return FilePath(path), mbx
 
     def open_local_mailbox(self, session):

--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -365,7 +365,8 @@ class ConfigManager(ConfigDict):
 
         if keydata:
             self.passphrases['DEFAULT'].copy(passphrase)
-            self._master_key = [''.join(keydata)]
+            # Prefix each key with a unique character to prevent optimization
+            self._master_key = [i + ''.join(keydata) for i in ('1', '2', '3')]
             self._master_key_ondisk = self.get_master_key()
             self._master_key_passgen = self.passphrases['DEFAULT'].generation
             return True
@@ -528,13 +529,14 @@ class ConfigManager(ConfigDict):
             self._unlocked_save(*args, **kwargs)
 
     def get_master_key(self):
-        if self._master_key[0] in self._master_key[1:]:
-            key = self._master_key[0]
-        elif self._master_key[1] in [self._master_key[0], self._master_key[2]]:
-            key = self._master_key[1]
+        if self._master_key[0][:1] in [self._master_key[1][1:], self._master_key[2][1:]]:
+            key = self._master_key[0][1:]
+        elif self._master_key[1] in [self._master_key[0][1:], self._master_key[2][1:]]:
+            key = self._master_key[1][1:]
         else:
             raise _raise("Failed to access master_key")
-        self._master_key = [key]*3
+        # Prefix each key with a unique character to prevent optimization
+        self._master_key = [i + key for i in ('1', '2', '3')]
         return key
 
     def _delete_old_master_keys(self, keyfile):

--- a/mailpile/httpd.py
+++ b/mailpile/httpd.py
@@ -551,7 +551,7 @@ class HttpServer(SocketServer.ThreadingMixIn, SimpleXMLRPCServer):
 
         # This hash includes the index ofuscation master key, which means
         # it should be very strongly unguessable.
-        self.secret = okay_random(64, session.config.master_key)
+        self.secret = okay_random(64, session.config.get_master_key())
 
         # Generate a new unguessable session cookie name on startup
         while not self.session_cookie:

--- a/mailpile/plugins/backups.py
+++ b/mailpile/plugins/backups.py
@@ -42,7 +42,7 @@ def _gunzip(data):
 
 def _decrypt(data, config):
     with DecryptingStreamer(cStringIO.StringIO(data),
-                            mep_key=config.master_key) as fd:
+                            mep_key=config.get_master_key()) as fd:
         data = fd.read()
         fd.verify(_raise=IOError)
     return data
@@ -121,7 +121,7 @@ class MakeBackup(Command):
         # The .ZIP is unencrypted, so generated contents needs protecting
         def _encrypt_and_add_data(filename, data):
             tempfile = os.path.join(config.tempfile_dir(), filename)
-            with EncryptingStreamer(config.master_key,
+            with EncryptingStreamer(config.get_master_key(),
                                     dir=config.tempfile_dir()) as fd:
                 fd.write(data)
                 fd.save(tempfile)

--- a/mailpile/plugins/contacts.py
+++ b/mailpile/plugins/contacts.py
@@ -1020,7 +1020,7 @@ def ProfileVCard(parent):
             config.event_log.log_event(event)
 
         def _create_new_key(self, vcard, keytype):
-            passphrase = okay_random(20, self.session.config.master_key
+            passphrase = okay_random(20, self.session.config.get_master_key()
                                      ).lower()
             passphrase = '-'.join([passphrase[i:i+4] for i in
                                    range(0, len(passphrase), 4)])

--- a/mailpile/plugins/core.py
+++ b/mailpile/plugins/core.py
@@ -1122,7 +1122,7 @@ class ConfigSet(Command):
                 fb = security.forbid_config_change(config, path)
                 if fb:
                     return self._error(fb)
-                elif path == 'master_key' and config.master_key:
+                elif path == 'master_key' and config.get_master_key():
                     return self._error(_('I refuse to change the master key!'))
 
         # We don't have transactions really, but making sure the HTTPD
@@ -1131,7 +1131,7 @@ class ConfigSet(Command):
             updated = {}
             for path, value in ops:
                 if not force:
-                    if path == 'master_key' and config.master_key:
+                    if path == 'master_key' and config.get_master_key():
                         raise ValueError('Need --force to change master key.')
                     if path == 'sys.http_no_auth':
                         raise ValueError('Need --force to change auth policy.')
@@ -1207,7 +1207,7 @@ class ConfigAdd(Command):
             fb = security.forbid_config_change(config, path)
             if fb:
                 return self._error(fb)
-            elif path == 'master_key' and config.master_key:
+            elif path == 'master_key' and config.get_master_key():
                 return self._error(_('I refuse to change the master key!'))
 
         # We don't have transactions really, but making sure the HTTPD
@@ -1263,7 +1263,7 @@ class ConfigUnset(Command):
             fb = security.forbid_config_change(config, v)
             if fb:
                 return self._error(fb)
-            elif v == 'master_key' and config.master_key:
+            elif v == 'master_key' and config.get_master_key():
                 return self._error(_('I refuse to change the master key!'))
 
         # We don't have transactions really, but making sure the HTTPD

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -338,7 +338,7 @@ class SetupMagic(Command):
     def make_master_key(self):
         session = self.session
         if (session.config.prefs.gpg_recipient not in (None, '', '!CREATE')
-                and not session.config.master_key
+                and not session.config.get_master_key()
                 and not session.config.prefs.obfuscate_index):
             #
             # This secret is arguably the most critical bit of data in the
@@ -357,10 +357,10 @@ class SetupMagic(Command):
             #   import math
             #   math.log((25 + 25 + 8) ** (12 * 4), 2) == 281.183...
             #
-            session.config.master_key = okay_random(12 * 4,
+            session.config._master_key = [okay_random(12 * 4,
                                                     '%s' % session.config,
                                                     '%s' % self.session,
-                                                    '%s' % self.data)
+                                                    '%s' % self.data)]*3
             if self._idx() and self._idx().INDEX:
                 session.ui.warning(_('Unable to obfuscate search index '
                                      'without losing data. Not indexing '
@@ -1290,7 +1290,7 @@ class Setup(SetupWelcome):
             ('language', lambda: config.prefs.language, SetupWelcome),
 
             # Stage 1: Basic security - a password
-            ('security', lambda: config.master_key, SetupPassword)
+            ('security', lambda: config.get_master_key(), SetupPassword)
         ]
 
     @classmethod

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -357,10 +357,10 @@ class SetupMagic(Command):
             #   import math
             #   math.log((25 + 25 + 8) ** (12 * 4), 2) == 281.183...
             #
-            session.config._master_key = [i + okay_random(12 * 4,
-                                                    '%s' % session.config,
-                                                    '%s' % self.session,
-                                                    '%s' % self.data) for i in ('1', '2', '3')]
+            session.config.set_master_key(okay_random(12 * 4,
+                                          '%s' % session.config,
+                                          '%s' % self.session,
+                                          '%s' % self.data))
             if self._idx() and self._idx().INDEX:
                 session.ui.warning(_('Unable to obfuscate search index '
                                      'without losing data. Not indexing '

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -357,10 +357,10 @@ class SetupMagic(Command):
             #   import math
             #   math.log((25 + 25 + 8) ** (12 * 4), 2) == 281.183...
             #
-            session.config._master_key = [okay_random(12 * 4,
+            session.config._master_key = [i + okay_random(12 * 4,
                                                     '%s' % session.config,
                                                     '%s' % self.session,
-                                                    '%s' % self.data)]*3
+                                                    '%s' % self.data) for i in ('1', '2', '3')]
             if self._idx() and self._idx().INDEX:
                 session.ui.warning(_('Unable to obfuscate search index '
                                      'without losing data. Not indexing '

--- a/mailpile/postinglist.py
+++ b/mailpile/postinglist.py
@@ -135,7 +135,7 @@ class PostingListContainer(object):
             return
 
         t = [time.time()]
-        encryption_key = self.config.master_key
+        encryption_key = self.config.get_master_key()
         outfile = self._SaveFile(self.config, self.sig)
         with self.lock:
             # Optimizing for fast loads, so deletion only happens on save.
@@ -318,7 +318,7 @@ class NewPostingList(object):
         return strhash(word, cls.HASH_LEN,
                        obfuscate=((config.prefs.obfuscate_index or
                                    config.prefs.encrypt_index) and
-                                  config.master_key))
+                                  config.get_master_key()))
 
 
 ##############################################################################
@@ -442,7 +442,7 @@ class OldPostingList(object):
         return strhash(word, cls.HASH_LEN,
                        obfuscate=((config.prefs.obfuscate_index or
                                    config.prefs.encrypt_index) and
-                                  config.master_key))
+                                  config.get_master_key()))
 
     @classmethod
     def SaveFile(cls, session, prefix):
@@ -544,7 +544,7 @@ class OldPostingList(object):
                                                                  outfile))
                 if output:
                     if self.config.prefs.encrypt_index:
-                        encryption_key = self.config.master_key
+                        encryption_key = self.config.get_master_key()
                         with EncryptingStreamer(encryption_key,
                                                 delimited=True,
                                                 dir=self.config.tempfile_dir(),

--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -227,8 +227,8 @@ class MailIndex(BaseIndex):
                   if gpgr not in (None, '', '!CREATE', '!PASSWORD')
                   else None)
 
-        if self.config.master_key:
-            with EncryptingStreamer(self.config.master_key,
+        if self.config.get_master_key():
+            with EncryptingStreamer(self.config.get_master_key(),
                                     delimited=True) as es:
                 es.write(data)
                 es.finish()

--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -727,7 +727,7 @@ def decrypt_and_parse_lines(fd, parser, config,
                             passphrase=None, gpgi=None,
                             _raise=IOError, error_cb=None):
     import mailpile.crypto.streamer as cstrm
-    symmetric_key = config and config.master_key or 'missing'
+    symmetric_key = config and config.get_master_key() or 'missing'
     passphrase_reader = (passphrase.get_reader()
                          if (passphrase is not None) else
                          (config.passphrases['DEFAULT'].get_reader()

--- a/mailpile/vcard.py
+++ b/mailpile/vcard.py
@@ -811,9 +811,9 @@ class MailpileVCard(SimpleVCard):
 
     def configure_encryption(self, config):
         if config:
-            dec = lambda: config.master_key
+            dec = lambda: config.get_master_key()
             enc = lambda: (config.prefs.encrypt_vcards and
-                           config.master_key)
+                           config.get_master_key())
             self.config = config
         else:
             enc = dec = lambda: None
@@ -1266,7 +1266,7 @@ class VCardStore(dict):
 
         try:
             prfs = self.config.prefs
-            key_func = lambda: self.config.master_key
+            key_func = lambda: self.config.get_master_key()
             paths = [(fn, os.path.join(self.vcard_dir, fn))
                      for fn in os.listdir(self.vcard_dir)
                      if fn.endswith('.vcf')]


### PR DESCRIPTION
The method get_master_key prevents data loss, through keeping mulitple instances
of the key and restores lost instances. If all instances are different it raises an error.