### PR TITLE
Fix hamburger menu rendering

### DIFF
--- a/shared-data/default-theme/css/default.css
+++ b/shared-data/default-theme/css/default.css
@@ -6362,6 +6362,7 @@ body {
   margin-top: 62px;
 }
 #content-tools {
+  position: relative;
   z-index: 10;
 }
 /* Copyright Footer Navigation */

--- a/shared-data/default-theme/less/app/global.less
+++ b/shared-data/default-theme/less/app/global.less
@@ -21,6 +21,7 @@
   }
 
   #content-tools {
+    position: relative;
     z-index: 10;
   }
 


### PR DESCRIPTION
I added position: relative property to content-tools id, it fixes the hamburger menu rendering (issue #2046 ), because z-index only works on positioned elements (position:absolute, position:relative, or position:fixed).