### PR TITLE
Integrate binary signing into windows build process

### DIFF
--- a/packages/windows-wix/README.md
+++ b/packages/windows-wix/README.md
@@ -21,6 +21,9 @@ Producing a package has minimal requirements:
   - git installed
   - mailpile checked out
   - administrator privileges
+  - Optional software signing requirements:
+      - a pkcs12 certificate suitable for software signing
+      - the software signing portion of the windows sdk (~50MB)
 
 To produce a package, go to the 'mailpile/packages/windows-wix/' directory and
 run `python provide -i provide.json`. It will output a directory called
@@ -33,6 +36,40 @@ is also possible to output partial products by adding multiple targets to the
 'export' configuration.
 
 Note: work in progress on customization and improving automation. See TODO.md.
+
+### Software Signing ###
+
+Software signing is an entirely optional build step. If not configured, the
+build will succeed, but produce several warnings that it was not able to sign
+the contents. While functional, an unsigned build does not provide authenticity
+assurances.
+
+Software signing uses `signtool.exe` to sign recognized file types prior to
+packaging, as well as the output package itself. Since Microsoft doesn't provide
+a portable/stand-alone download for signtool, anyone wanting to sign a mailpile
+package must install the relevant part of the windows sdk. The install feature
+"Windows SDK Signing Tools for Desktop Apps" should be enough on it's own.
+
+The packaging script will attempt to detect `signtool.exe` in it's default
+install location. This can be checked by inspecting the help output from
+`python provide -h`: If the default for `--config_signtool` is `signtool.exe`,
+provide was not able to locate signtool on the local machine, and expects it
+to exist on the system path. The location of `signtool.exe` can also be defined
+by manually setting this parameter.
+
+Actually signing software components requires a pkcs12 PKI certificate capable
+of software signing. A self-signed cert can be made following these intsructions
+https://stackoverflow.com/questions/9428335/make-your-own-certificate-for-signing-files
+
+Alternately, a software signing certifacte can be sourced. Note that Microsoft
+only includes select few roots of trust by default--any other CA, no matter how
+valid, will not be validated a vanila windows install. Check the list carefully!
+
+With a certificate in hand, the `--config_signing_key` and
+`--config_signing_passwd` options can be set to enable software signing. Both
+are required as it is assumed the key is stored in an encrypted state.
+Additionally, the signing timestamp server can be configured--see
+`python provide -h` for full details.
 
 ## Integration points ##
 

--- a/packages/windows-wix/provide/build.py
+++ b/packages/windows-wix/provide/build.py
@@ -50,7 +50,7 @@ class Build(object):
                 except subprocess.CalledProcessError as e:
                     error_file.seek(0)
                     error_text = error_file.read()
-                    self.build.log().critical("stderr from exception:\n" + error_text)
+                    self.build.log().critical("stderr from exception:\n" + error_text.decode())
                     self.build.log().critical("stdout from exception:\n" + e.output)
                     e.stderr = error_text
                     raise

--- a/packages/windows-wix/provide/build.py
+++ b/packages/windows-wix/provide/build.py
@@ -5,6 +5,7 @@ import argparse
 import datetime
 import logging
 import json
+import itertools
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +177,7 @@ class Build(object):
         self._defaults = {}
         self._options = {}
 
-    def provide(self, *keywords):
+    def provide(self, *keywords, **extra):
         '''
         decorator that registers a provider for a keyword
         '''
@@ -187,7 +188,7 @@ class Build(object):
             return provider
         return decorator
 
-    def default_config(self, *keywords):
+    def default_config(self, *keywords, **extra):
         '''
         decorator that registers a provider for a default configuration
         '''
@@ -197,6 +198,12 @@ class Build(object):
                 self._defaults[keyword] = callback
             return callback
         return decorator
+
+    def define_config(self, keyword, doc):
+        '''
+        Configuration value without default.
+        '''
+        self._options[keyword] = doc
 
     def context(self, cache, config={}):
         '''
@@ -209,9 +216,20 @@ class Build(object):
         Create an argument parser for this build
         '''
         parser = parser or argparse.ArgumentParser()
-        for keyword, doc in self._defaults.items():
+        for keyword, func in self._defaults.items():
+            help_str = repr(func(keyword))
+            if func.__doc__:
+                desc = func.__doc__.strip()
+                if not desc.endswith('.'):
+                    desc += '.'
+                help_str = '{} Default: {}'.format(desc, help_str)
+                
             parser.add_argument('--config_' + keyword.replace('-', '_'),
-                                help=repr(doc(keyword)))
+                                help=help_str)
+
+        for keyword, desc in self._options.items():                   
+            parser.add_argument('--config_' + keyword.replace('-', '_'),
+                                help=desc)
         return parser
 
     def parse_config(self, args):
@@ -219,7 +237,7 @@ class Build(object):
         create a context from argv
         '''
         config = {}
-        for key in self._defaults.keys():
+        for key in itertools.chain(self._defaults.keys(), self._options.keys()):
             test = 'config_' + key.replace('-', '_')
             value = getattr(args, test)
             if value is not None:

--- a/packages/windows-wix/provide/scripts/bootstrap.py
+++ b/packages/windows-wix/provide/scripts/bootstrap.py
@@ -15,7 +15,10 @@ def bind(framework):
     @framework.default_config('bootstrap')
     def config_bootstrap(keyword):
         '''
-        Empty config--don't do anything by default.
+        Inner configuration JSON for a fully bootstrapped build. All options
+        passed here are forwarded to the checked out build. The bootstrap env
+        will inherit this build's cache directory and log level. A second log
+        file will be created for this build.
         '''
         
         return None

--- a/packages/windows-wix/provide/scripts/external.py
+++ b/packages/windows-wix/provide/scripts/external.py
@@ -1,12 +1,37 @@
+import os
+import os.path
+import itertools
 
 def bind(build):
 
     @build.default_config('git', 'signtool')
     def default_config_env(keyword):
+        '''
+        Commands expected to exist on PATH.
+        '''
+        return keyword + '.exe'
+
+    @build.default_config('signtool')
+    def default_config_sdk(keyword):
+        '''
+        Try to discover tools from the windows sdk, otherwise expect on PATH.
+        '''
+        win_sdk_root = 'C:\\Program Files (x86)\\Windows Kits\\10\\bin'
+        versions = os.listdir(win_sdk_root)
+        versions.sort(reverse=True)
+        template = win_sdk_root + '\\{}\\{}\\{}.exe'
+        for version, platform in itertools.product(versions,('x86','x64')):
+            path = template.format(version, platform, keyword)
+            if os.path.exists(path):
+                return path
+
         return keyword + '.exe'
 
     @build.provide('git', 'signtool')
-    def provide_from_env(build, keyword):
+    def provide_from_config(build, keyword):
+        '''
+        Trivial wrapper to inject invokables from config
+        '''
         exe_path = build.config(keyword)
 
         build.publish(keyword, exe_path)

--- a/packages/windows-wix/provide/scripts/git_checkout.py
+++ b/packages/windows-wix/provide/scripts/git_checkout.py
@@ -5,11 +5,18 @@ def bind(build):
 
     @build.default_config('mailpile', 'gui-o-matic')
     def config_gui_o_matic(keyword):
+        '''
+        Configure git checkout url and commit/branch.
+        '''
         return {'commit': 'master',
                 'repo': 'https://github.com/mailpile/{}'.format(keyword)}
 
     @build.provide('mailpile', 'gui-o-matic')
     def provide_checkout(build, keyword):
+        '''
+        Checkout the specified git repository to the specified commit/branch and
+        delete git files.
+        '''
         build.depend('git')
         build.depend('root')
         dep_path = build.invoke('path', keyword)

--- a/packages/windows-wix/provide/scripts/msi_package.py
+++ b/packages/windows-wix/provide/scripts/msi_package.py
@@ -92,7 +92,8 @@ def bind(build):
         # sign binary content
         #
         for path in content_paths.values():
-            build.invoke('sign_tree', path)
+            if os.path.exists(path):
+                build.invoke('sign_tree', path)
 
         # create the template for building the wix config
         #

--- a/packages/windows-wix/provide/scripts/sign_tree.py
+++ b/packages/windows-wix/provide/scripts/sign_tree.py
@@ -1,18 +1,79 @@
+import os
+import os.path
+
+def is_signable(path):
+    '''
+    Check if a file is in the PE format by looking for the 'MZ' magic.
+    '''
+    try:
+        # FIXME--not the correct check...
+        with open(path, 'rb') as handle:
+            magic = handle.read(2)
+            if magic == "\x7F\x45":
+                return True
+    except IOError:
+        pass
+
+    recognized_formats = ('.msi', '.exe', '.dll', '.pyd')
+    return any( map( path.endswith, recognized_formats) )
 
 def bind(build):
+    @build.default_config('timestamp_server')
+    def config_signing_timestamp_server(keyword):
+        '''
+        Time server for signing execubles
+        '''
+        return 'http://timestamp.digicert.com'
+
+    build.define_config('signing_key',
+                        'Key for signing PE files (pkcs12 format).')
+    build.define_config('signing_passwd',
+                        'Password for signing key.')
+    
     @build.provide('sign_tree')
     def provide_sign_tree(build, keyword):
+        '''
+        Provide tool to sign all executables in the specified build path
+        '''
         build.depend('signtool')
         try:
-            key = build.config('signing_key')
+            key = os.path.abspath(build.config('signing_key'))
+            build.log().debug('Using signing key {}'.format(key))
+            password = build.config('signing_passwd')
+
+            def sign_file(path):
+                '''
+                Sign a single file, if it's in PE format
+                '''
+                if is_signable(path):
+                    build.log().info("Signing '{}'".format(path))
+                    build.invoke('signtool',
+                                 '/f', key,
+                                 '/p', password,
+                                 '/tr', build.config('timestamp_server'),
+                                 '/tf', 'sha512',
+                                 '/fd', 'sha512')
 
             # TODO: publish a recursive scanner.
-
+            def sign_tree(path):
+                '''
+                Sign all detected PE files in the specified path
+                '''
+                build.log().debug("Scanning '{}' for signable files...".format(path))
+                assert(os.path.exists(path))
+                for root, dirs, files in os.walk(path):
+                    for name in files:
+                        path = os.path.join(root,name)
+                        sign_file(path)
+                        
         except KeyError:
             build.log().warning('No signing key configured--outputs will not be signed')
 
             def sign_tree(path):
-                build.log().info("ignoring request to sign tree '{}'".format(path))
+                '''
+                Stub to support debug/test unsigned builds.
+                '''
+                build.log().warn("Ignoring request to sign tree '{}'".format(path))
 
         build.publish(keyword, sign_tree)
 

--- a/packages/windows-wix/provide/scripts/sign_tree.py
+++ b/packages/windows-wix/provide/scripts/sign_tree.py
@@ -47,12 +47,13 @@ def bind(build):
                 '''
                 if is_signable(path):
                     build.log().info("Signing '{}'".format(path))
-                    build.invoke('signtool',
+                    build.invoke('signtool', 'sign',
                                  '/f', key,
                                  '/p', password,
                                  '/tr', build.config('timestamp_server'),
-                                 '/tf', 'sha512',
-                                 '/fd', 'sha512')
+                                 '/td', 'sha512',
+                                 '/fd', 'sha512',
+                                 path)
 
             # TODO: publish a recursive scanner.
             def sign_tree(path):


### PR DESCRIPTION
Microsoft supports signing various PE-related file formats via software signing certificate and the signtool.exe executable from the windows SDK. Integrating signing into the build process provides authenticity assurances to end users by allowing them to verify signed content and the installer package itself.

This pull request replaces the signing stub tool in the windows-wix packaging scripts with full-fledged signing functionality that signs exe, dll, pyd, and msi content in the build/packaging environment. The signing functionality is optional, and defaults to a warning if not configured--equivalent to the stub state. When configured, all recognized build content is signed prior to packaging, as is each msi package produced.

As a disclosure, signing is not available for non-PE content--python scripts, images, etc. do have some checksum integrity via the msi/windows installer system, but no direct per-file authenticity checks once installed.

Instructions are provided for generating an appropriate self signed cert and using it in the build process. Note that microsoft only recognizes a select few CAs by default, please consult MSDN documentation prior to acquiring a signed certificate for software signing.