### PR TITLE
Fix broken « report a bug » display

### DIFF
--- a/shared-data/default-theme/html/partials/topbar.html
+++ b/shared-data/default-theme/html/partials/topbar.html
@@ -31,9 +31,9 @@
             ><span class="link-icon icon-x"></span></a>
         </li>
   {%- if is_dev_version() %}{# FIXME ! #}
-        <li style="width: 7em; margin: 10px 0 -10px 0; white-space: nowrap;"
+        <li style="margin: 10px 0 -10px 0"
             class="tablet-hide mobile-hide">
-          <a class="auto-modal" data-flags="" data-icon="icon-code"
+          <a class="auto-modal" style="width: unset" data-flags="" data-icon="icon-code"
              title="{{_('How to report bugs')}}"
              href="{{ U('/page/contribute/bugs.html') }}">{{_("Report Bugs")}}</a>
         </li>


### PR DESCRIPTION
That is not more or less elegant CSS than before, but it fixes display.

before:


![image](https://user-images.githubusercontent.com/429633/41502614-63bcf99e-71be-11e8-95f8-719102f9a113.png)


after:

![image](https://user-images.githubusercontent.com/429633/41502607-43f1d67a-71be-11e8-93cc-8cd712230877.png)
