### PR TITLE
"Factory Reset" for user tags

### DIFF
--- a/mailpile/plugins/tags.py
+++ b/mailpile/plugins/tags.py
@@ -35,6 +35,10 @@ _plugins.register_config_section('tags', ["Tags", {
         'replied', 'fwded', 'tagged', 'read', 'ham',  # behavior tracking tags
         'trash', 'spam'                               # junk mail tags
     ], 'tag'],
+    'default': ['Default tag type', [
+        'unread', 'inbox', 'drafts', 'outbox', 'sent',
+        'spam', 'trash', 'photos', 'documents', 'all'
+    ], 'tag'],
     'flag_hides': ['Hide tagged messages from searches?', 'bool', False],
     'flag_editable': ['Mark tagged messages as editable?', 'bool', False],
     'flag_msg_only': ['Never apply to entire conversations', 'bool', False],

--- a/shared-data/default-theme/html/jsapi/ui/events.js
+++ b/shared-data/default-theme/html/jsapi/ui/events.js
@@ -26,6 +26,15 @@ $(document).on('click', '#button-modal-add-tag', function(e) {
   Mailpile.UI.Modals.TagAddProcess($(this).data('location'));
 });
 
+$(document).on('click', '#button-reset-tags', function(e) {
+  e.preventDefault();
+  var answer = confirm("Are you sure you want to reset tags?");
+  if (answer == true) {
+    Mailpile.API.reset_tags_get({}, function(result) {});
+    var elem = $('#button-sidebar-organize');
+    Mailpile.UI.Sidebar.OrganizeToggle(elem);
+  }
+});
 
 $(document).on('click', '.hide-donate-page', function(e) {
   Mailpile.API.settings_set_post({ 'web.donate_visibility': 'False' }, function(e) {

--- a/shared-data/default-theme/html/jsapi/ui/sidebar.js
+++ b/shared-data/default-theme/html/jsapi/ui/sidebar.js
@@ -195,6 +195,13 @@ Mailpile.UI.Sidebar.OrganizeToggle = function(elem) {
         '<span class="icon-settings"></span></a>');
     });
 
+    // Add Reset Button
+    $elem.before(
+      '<a style="float: left" href="#" id="button-reset-tags"' +
+      ' title="{{_("Factory Reset")}}">' +
+      '<span class="icon icon-code"></span>' +
+      '<span class="text">{{_("Factory Reset")}}</span></a>');
+
     // Update Edit Button
     $elem.data('state', 'editing');
     $elem.find('span.icon').removeClass('icon-settings').addClass('icon-checkmark');
@@ -209,10 +216,13 @@ Mailpile.UI.Sidebar.OrganizeToggle = function(elem) {
     // Update Cursor Make Links Work
     $('.sidebar-sortable li').removeClass('is-editing');
 
-    // Show Notification / Remove Settings Button
+    // Show Notification 
     $('a.sidebar-tag .notification').show();
     $('li.sidebar-tag .sidebar-tag-expand').show();
+
+    // Remove Settings Button and Reset Button
     $('.sidebar-tag-settings').remove();
+    $('#button-reset-tags').remove();
 
     // Hide tags that are normally hidden
     $('li.sidebar-tag.should-hide').slideUp();


### PR DESCRIPTION
This PR implements "Factory Reset" for user tags, it works basically as described in #2031 .

I added a new "default" attribute to tags that are initially configured on setup, so that we know what was the original tag.
