### PR TITLE
Changed os.path to mailpile.vfs.FilePath

### DIFF
--- a/mailpile/plugins/migrate.py
+++ b/mailpile/plugins/migrate.py
@@ -7,6 +7,7 @@ from mailpile.mail_source.local import LocalMailSource
 from mailpile.plugins import PluginManager
 from mailpile.util import *
 from mailpile.vcard import *
+from mailpile.vfs import FilePath
 
 
 _plugins = PluginManager(builtin=__file__)
@@ -59,24 +60,24 @@ def migrate_routes(session):
 
 def migrate_mailboxes(session):
     config = session.config
+    fpath = FilePath()
 
-    # FIXME: This should be using mailpile.vfs.FilePath
     # FIXME: Link new mail sources to a profile... any profile?
 
     def _common_path(paths):
-        common_head, junk = os.path.split(paths[0])
+        common_head, junk = fpath.split(paths[0])
         for path in paths:
-            head, junk = os.path.split(path)
+            head, junk = fpath.split(path)
             while (common_head and common_head != '/' and
                    head and head != '/' and
                    head != common_head):
                 # First we try shortening the target path...
                 while head and head != '/' and head != common_head:
-                    head, junk = os.path.split(head)
+                    head, junk = fpath.split(head)
                 # If that failed, lop one off the common path and try again
                 if head != common_head:
-                    common_head, junk = os.path.split(common_head)
-                    head, junk = os.path.split(path)
+                    common_head, junk = fpath.split(common_head)
+                    head, junk = fpath.split(path)
         return common_head
 
     mailboxes = []

--- a/mailpile/vfs.py
+++ b/mailpile/vfs.py
@@ -124,6 +124,44 @@ class FilePath(object):
                                 *[FilePath(fp).raw_fp for fp in fpaths])
         return FilePath(binary_fp=joined, flags=FilePath(fpaths[-1]).flags)
 
+    def split(self, p):
+        """Splits a pathname"""
+        d, p = splitdrive(p)
+        i = len(p)
+        while i and p[i-1] not in '/\\':
+            i = i - 1
+        head, tail = p[:i], p[i:]
+        head2 = head
+        while head2 and head2[-1] in '/\\':
+            head2 = head2[:-1]
+        head = head2 or head
+        return d + head, tail
+
+    def splitdrive(self, p):
+        """Splits a pathname into a UNC sharepoint"""
+        sep = "\\"
+        altsep = "/"
+        if len(p) > 1:
+        normp = p.replace(altsep, sep)
+        if (normp[0:2] == sep*2) and (normp[2:3] != sep):
+            # is a UNC path:
+            # vvvvvvvvvvvvvvvvvvvv drive letter or UNC path
+            # \\machine\mountpoint\directory\etc\...
+            #           directory ^^^^^^^^^^^^^^^
+            index = normp.find(sep, 2)
+            if index == -1:
+                return '', p
+            index2 = normp.find(sep, index + 1)
+            # a UNC path can't have two slashes in a row
+            # (after the initial two)
+            if index2 == index + 1:
+                return '', p
+            if index2 == -1:
+                index2 = len(p)
+            return p[:index2], p[index2:]
+        if normp[1] == ':':
+            return p[:2], p[2:]
+    return '', p
 
 class MailpileVfsBase(object):
     """


### PR DESCRIPTION
Hey Mailpile maintainers and contributors, thank you for this wicked sick mail client, I really love it! Can't wait till it hits 1.0!

This pull request comes at a really awkward time where I was trying to solve one of issues listed here on GitHub and I stumbled on this FIXME and I thought, "Hey, I could do this!" So, I went on ahead and added the split and splithead functions to the vfs and then changed the os.path to vfs.FilePath in migrate.

Let me know if I need to contribute anything else! Thank you!