### PR TITLE
Add pysocks dependency to debian pkg

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -61,6 +61,7 @@ Depends: ${misc:Depends},
          python-imgsize,
          python-socksipychain,
          python-dns,
+         python-socks,
          python-pgpdump,
          python-pil
 Recommends: tor, wamerican-small, gnupg-curl


### PR DESCRIPTION
Seems to have been forgotten in 03ebb435b5e97ae15a8f8f79ba015beac1a465b5

I also updated the wiki https://github.com/mailpile/Mailpile/wiki/Getting-started-on-Linux

(maybe Debian is not enough and there are other pkgs to be updated)