### PR TITLE
Recognize vfs aliases /Mailpile$, /Share$, /Home$ in cd command.

### DIFF
--- a/mailpile/plugins/core.py
+++ b/mailpile/plugins/core.py
@@ -990,7 +990,8 @@ class ChangeDir(ListDir):
     def command(self, args=None):
         try:
             args = list((args is None) and self.args or args or [])
-            os.chdir(os.path.expanduser(args.pop(0).encode('utf-8')))
+            os.chdir(FilePath.unalias(
+                        os.path.expanduser(args.pop(0).encode('utf-8'))))
             return ListDir.command(self, args=['.'])
         except (OSError, IOError, UnicodeEncodeError), e:
             return self._error(_('Failed to change directories: %s') % e)


### PR DESCRIPTION
The CLI ls (browse) command and other commands recognize the aliases created by Maipile's VFS. For some reason cd does not. This two line patch implements the aliases in cd.