### PR TITLE
Cryptoinfo buglet fix

### DIFF
--- a/mailpile/crypto/gpgi.py
+++ b/mailpile/crypto/gpgi.py
@@ -158,7 +158,7 @@ class GnuPGResultParser:
 
             elif keyword == "ENC_TO":
                 keylist = encryption_info.get("have_keys", [])
-                if data[0] not in keylist:
+                if data[1] not in keylist:
                     keylist.append(data[1].strip())
                 encryption_info["have_keys"] = list(set(keylist))
                 

--- a/mailpile/crypto/state.py
+++ b/mailpile/crypto/state.py
@@ -81,7 +81,7 @@ class CryptoInfo(dict):
 
         parent = self.parent
         while parent is not None:
-            self.parent.bubbles.append(self)
+            parent.bubbles.append(self)
             parent = parent.parent
 
     def mix_bubbles(self):

--- a/shared-data/default-theme/html/settings/privacy.html
+++ b/shared-data/default-theme/html/settings/privacy.html
@@ -291,7 +291,13 @@
 
   <a name="data-security"></a><div class="setting-group">
     <h3>{{_("Securing Your Data")}}</h3>
+
     <div class="explanation">
+      <p class="what">
+        <span class="icon icon-settings"></span>
+        {{_("Your Mailpile stores data here:")}}<br>
+        <a target=_blank href='file:///{{ config.workdir }}/'>{{ config.workdir }}</a>
+      </p>
       <p class="what">
         <span class="icon icon-lock-closed"></span>
         {{_("Mailpile can encrypt your e-mail, search engine and settings.")}}


### PR DESCRIPTION
This fixes two apparent typos in the crypto code.

It appear that the typo in state.py would limit "bubbling up" to just one level at a time. This probably would cause problems infrequently because mime.py, which uses bubble_up(), moves up the mime part hierarchy one level at a time, so the "bubbles" would work their way up regardless. However, the code allows some levels would be skipped, so the bug should be fixed.

The gpgi.py fix could result in duplication of entries in  keylist, but that duplication would likely be fixed byalmost the next line of code.

Nevertheless, better to have code that is correct.

The state.py fix w as referenced on IRC:

```
[onsdag 27 juni 2018] [kl. 10:16:20 EDT] <JackDca>	BjarniRunar: Help! I'm looking at current master, mailpile/crypto/state.py, line 84 "self.parent.bubbles.append(self)". Should that be "parent.bubbles.append(self)", that is, reference "parent" instead of "self.parent"? Or is my inexperience with Python showing? Any hints would be appreciated.
[onsdag 27 juni 2018] [kl. 13:11:56 EDT] <BjarniRunar>	JackDca: yes, that looks odd
[onsdag 27 juni 2018] [kl. 13:12:46 EDT] <BjarniRunar>	probably broken. That stuff needs unit tests.
[onsdag 27 juni 2018] [kl. 15:48:28 EDT] <JackDca>	BjarniRunar: Looks like it would limit bubbling up to just one level. But, because UnwrapMimeCrypto() is called recursively, it starts at the deepest level and works its way up one level at a time calling bubble_up() and mix_bubbles() (mime.py lines 350 ...) which would achieve the same result as long as there are no levels with bubbly=false. So the code probably mostly works anyway.  
[torsdag 28 juni 2018] [kl. 05:46:58 EDT] <BjarniRunar>	JackDca: I agree with that analysis!
[torsdag 28 juni 2018] [kl. 08:41:50 EDT] <JackDca>	BjarniRunar: OK. I'll try a fix locally.

```