### PR TITLE
FIx path so development version can coexist with .deb installed version

### DIFF
--- a/scripts/mailpile
+++ b/scripts/mailpile
@@ -8,7 +8,7 @@ mailpile_root = os.path.dirname(     # Mailpile root
     )
 )
 
-sys.path.append(mailpile_root)
+sys.path = [mailpile_root] + sys.path
 
 from mailpile.app import Main
 Main(sys.argv[1:])


### PR DESCRIPTION
On Debian stretch, when Mailpile has been installed from the released `.deb,` a locally installed development version using virtualenv, launched with `scripts/mailpile`, does not work.

Specifically, when the browser is launched, the screen displays only the message `Template not found`.

This appears to be caused by some file being retrieved from `/usr` instead of from the development version.

This is fixed if `script/mailpile` is patched so that the `Mailpile` code directory is prepended to the path instead of appended to it.

This should have no effect on the .deb installed version since `script/mailpile` does not appear to be installed to /usr from the `.deb`.


