### PR TITLE
Check wether url prefix is fully present

### DIFF
--- a/mailpile/www/jinjaextensions.py
+++ b/mailpile/www/jinjaextensions.py
@@ -741,7 +741,7 @@ class MailpileCommand(Extension):
         url = ''.join([unicode(p) for p in urlparts])
         if url[:1] in ('/', ):
             http_path = self.env.session.config.sys.http_path or ''
-            if not url.startswith(http_path):
+            if not url.startswith(http_path+'/'):
                 url = http_path + url
         return self._safe(url)
 

--- a/shared-data/default-theme/html/jsapi/index.js
+++ b/shared-data/default-theme/html/jsapi/index.js
@@ -353,7 +353,7 @@ Mailpile.API = {
 
   U: function(original_url) {
     var prefix = "{{ config.sys.http_path }}";
-    if (original_url.indexOf(prefix) != 0) {
+    if (original_url.indexOf(prefix+'/') != 0) {
       return prefix + original_url;
     }
     return original_url;


### PR DESCRIPTION
When using 'sys.http_path' as '/c' whenever the certificate tool dialog
needs to be brought up, the U function gets confused and can lead to
certain urls not working, therefore: check the full prefix instead, to
avoid other combinations to cause the same problem

Fixes #2106