### PR TITLE
Add support for retrieving keys using Web Key Directory

### DIFF
--- a/mailpile/crypto/keydata.py
+++ b/mailpile/crypto/keydata.py
@@ -1,0 +1,54 @@
+from pgpdump.utils import PgpdumpException
+import time
+import pgpdump
+
+def _get_creation_time(m):
+    """Compatibility shim, for differing versions of pgpdump"""
+    try:
+        return m.creation_time
+    except AttributeError:
+        try:
+            return m.datetime
+        except AttributeError:
+            return datetime.datetime(1970, 1, 1, 00, 00, 00)
+
+
+def get_keydata(data):
+    results = []
+    try:
+        if "-----BEGIN" in data:
+            ak = pgpdump.AsciiData(data)
+        else:
+            ak = pgpdump.BinaryData(data)
+        packets = list(ak.packets())
+    except (TypeError, IndexError, PgpdumpException):
+        return []
+
+    now = time.time()
+    for m in packets:
+        try:
+            if isinstance(m, pgpdump.packet.PublicKeyPacket):
+                size = str(int(1.024 *
+                               round(len('%x' % (m.modulus or 0)) / 0.256)))
+                validity = ('e'
+                            if (0 < (int(m.expiration_time or 0)) < now)
+                            else '')
+                results.append({
+                    "fingerprint": m.fingerprint,
+                    "created": _get_creation_time(m),
+                    "validity": validity,
+                    "keytype_name": (m.pub_algorithm or '').split()[0],
+                    "keysize": size,
+                    "uids": [],
+                })
+            if isinstance(m, pgpdump.packet.UserIDPacket) and results:
+                # FIXME: This used to happen with results=[], does that imply
+                #        UIDs sometimes come before the PublicKeyPacket?
+                results[-1]["uids"].append({"name": m.user_name,
+                                            "email": m.user_email})
+        except (TypeError, AttributeError, KeyError, IndexError, NameError):
+            import traceback
+            traceback.print_exc()
+
+    # This will only return keys that have UIDs
+    return [k for k in results if k['uids']]

--- a/mailpile/plugins/keylookup/__init__.py
+++ b/mailpile/plugins/keylookup/__init__.py
@@ -11,7 +11,7 @@ from mailpile.util import *
 from mailpile.vcard import AddressInfo
 
 
-__all__ = ['email_keylookup', 'nicknym', 'dnspka']
+__all__ = ['email_keylookup', 'nicknym', 'dnspka', 'wkd']
 
 KEY_LOOKUP_HANDLERS = []
 
@@ -510,3 +510,4 @@ register_crypto_key_lookup_handler(KeyserverLookupHandler)
 # things happy enough with the circular dependencies...
 from mailpile.plugins.keylookup.email_keylookup import EmailKeyLookupHandler
 from mailpile.plugins.keylookup.dnspka import DNSPKALookupHandler
+from mailpile.plugins.keylookup.wkd import WKDLookupHandler

--- a/mailpile/plugins/keylookup/wkd.py
+++ b/mailpile/plugins/keylookup/wkd.py
@@ -1,0 +1,88 @@
+import hashlib
+import urllib2
+
+from mailpile.conn_brokers import Master as ConnBroker
+from mailpile.crypto.keydata import get_keydata
+from mailpile.i18n import gettext
+from mailpile.plugins.keylookup import LookupHandler
+from mailpile.plugins.keylookup import register_crypto_key_lookup_handler
+
+ALPHABET = "ybndrfg8ejkmcpqxot1uwisza345h769"
+SHIFT = 5
+MASK = 31
+
+#
+#  Encodes data using ZBase32 encoding
+#  See: https://tools.ietf.org/html/rfc6189#section-5.1.6
+#
+def _zbase_encode(data):
+    if len(data) == 0:
+        return ""
+    buffer = ord(data[0])
+    index = 1
+    bitsLeft = 8
+    result = ""
+    while bitsLeft > 0 or index < len(data):
+        if bitsLeft < SHIFT:
+            if index < len(data):
+                buffer = buffer << 8
+                buffer = buffer | (ord(data[index]) & 0xFF)
+                bitsLeft = bitsLeft + 8
+                index = index + 1
+            else:
+                pad = SHIFT - bitsLeft
+                buffer = buffer << pad
+                bitsLeft = bitsLeft + pad
+        bitsLeft = bitsLeft - SHIFT
+        result = result + ALPHABET[MASK & (buffer >> bitsLeft)]
+    return result
+
+_ = lambda t: t
+
+#
+#  Support for Web Key Directory (WKD) lookup for keys.
+#  See: https://wiki.gnupg.org/WKD and https://datatracker.ietf.org/doc/draft-koch-openpgp-webkey-service/
+#
+class WKDLookupHandler(LookupHandler):
+    NAME = _("Web Key Directory")
+    TIMEOUT = 10
+    PRIORITY = 200
+
+    def __init__(self, *args, **kwargs):
+        LookupHandler.__init__(self, *args, **kwargs)
+        self.key_cache = { }
+
+    def _score(self, key):
+        return (12, _('Found key in Web Key Directory'))
+
+    def _lookup(self, address, strict_email_match=True):
+        local, _, domain = address.partition("@")
+        local_part_encoded = _zbase_encode(hashlib.sha1(local.lower().encode('utf-8')).digest())
+        url = "https://%s/.well-known/openpgpkey/hu/%s" % (domain, local_part_encoded)
+
+        with ConnBroker.context(need=[ConnBroker.OUTGOING_HTTP]):
+            try:
+                r = urllib2.urlopen(url)
+            except urllib2.HTTPError as e:
+                if e.code == 404:
+                    return { }
+                raise
+
+        result = r.read()
+
+        keydata = get_keydata(result)[0]
+
+        self.key_cache[keydata["fingerprint"]] = result
+
+        return {keydata["fingerprint"]: keydata}
+
+    def _getkey(self, keydata):
+        data = self.key_cache.pop(keydata["fingerprint"])
+        if data:
+            return self._gnupg().import_keys(data)
+        else:
+            raise ValueError("Key not found")
+
+
+_ = gettext
+register_crypto_key_lookup_handler(WKDLookupHandler)


### PR DESCRIPTION
This change allows looking up keys using Web Key Directory scheme.
Functions for parsing key data have been extracted from email_keylookup.py into crypto/keydata.py as WKD also uses them for parsing keys.

Fixes #2117.

This is how it looks like when searching for `torvalds@kernel.org`:

![screenshot from 2018-08-10 14-21-10](https://user-images.githubusercontent.com/1718963/43959275-80cdcdb8-9cae-11e8-80ca-8f52db25574f.png)

(I also maintain an address `test-wkd@metacode.biz` that can be found only using WKD).

I would very much appreciate comments about style (as I don't write Python) and suggestions how to mock HTTP calls for unit tests (all other lookup mechanisms have tests). Various constants (score, timeout, priority) are of course also to be discussed.