### PR TITLE
Fix Excessive Timeouts

### DIFF
--- a/shared-data/default-theme/html/jsapi/global/eventlog.js
+++ b/shared-data/default-theme/html/jsapi/global/eventlog.js
@@ -61,11 +61,15 @@ EventLog.poll = function() {
   // 3) Other tabs may rely on us putting things in localStorage that we
   //    ourselves don't care about.
   //
+  //time for server to wait for new events
+  var waittime = 30;
+  //extra time to account for processing time on backend
+  var buffer = 5;
   EventLog.request({
     since: EventLog.last_ts,
     gather: (EventLog.last_ts < 0) ? 0.2 : 1.0,
-    wait: 30,
-    _timeout: (Mailpile.ajax_timeout * 3)
+    wait: waittime,
+    _timeout: (waittime+buffer)*1000
   });
 };
 


### PR DESCRIPTION
Fixes excessive timeouts by adding a 5 second buffer to the ajax request timeout and basing the timeout on the given wait time to account for server overhead when no new events are found.

Based on #2168 Part 2.
The problem was that the ajax timeout set for the GET request for the regular polling of event logs was exactly the same as the wait time specified in the request, but due to server overhead, actually took a little bit more time than the wait time when no events were found. This caused an AJAX timeout whenever no events were found. 
This was fixed by making the timeout not hard coded and instead scales based on the given wait time and now has a 5 second buffer to account for server overhead. This was tested by having Mailpile open for an hour and looking at the number of timeouts shown in chromes developer console. Over the course of an hour there were no timeouts compared to the previous implementation which timed out frequently.