### PR TITLE
Added undo functionality in event log for tag events

### DIFF
--- a/shared-data/default-theme/html/jsapi/global/eventlog.js
+++ b/shared-data/default-theme/html/jsapi/global/eventlog.js
@@ -263,3 +263,16 @@ $(document).ready(function () {
   }, false);
   window.setTimeout(EventLog.clear_old_events, EventLog.TIMEOUT_CHECK_OLD_EVENTS * 1000);
 });
+
+/* Notification - Undo */
+$(document).on('click', '.eventlog-undo', function() {
+  var event_id = $(this).data('event_id');
+  Mailpile.API.logs_events_undo_post({ event_id: event_id }, function(result) {
+    if (result.status === 'success') {
+      window.location.reload(true);
+    }
+    else {
+      alert("{{ _('Oops. Mailpile failed to complete your task.') }}");
+    }
+  });
+});

--- a/shared-data/default-theme/html/logs/events/index.html
+++ b/shared-data/default-theme/html/logs/events/index.html
@@ -28,6 +28,14 @@
        href="{{ U('/logs/events/?ui_expand=', event.event_id, '#', event.event_id) }}">
       {{ event.message }}
     </a>
+    {%- if event.data and event.data.undo %}
+    <a href="#"
+       title="{{ event.data.undo }}"
+       class="auto-modal eventlog-undo"
+       data-event_id="{{ event.event_id }}"
+       style="font-style: italic;
+              text-decoration: underline;">{{ _('Undo') }}</a>
+    {%- endif %}
   </p>
   {%- if ui_expand == event.event_id %}
   <p class="subsection">
@@ -35,13 +43,6 @@
   </p>
   {%- endif %}
 {# FIXME:
-    <td class="undo">
-      {%- if event.data.undo %}
-      <a href="/logs/events/undo/?event_id={{ event.event_id }}"
-         title="{{ event.data.undo }}"
-         class="auto-modal">{{ _('Undo') }}</a>
-      {%- endif %}
-    </td>
     <td class="checkbox">
       <input type="checkbox" name="mid" value="{{ event.event_id }}">
     </td>


### PR DESCRIPTION
This PR adds the undo button to tag events that works the same as the button in the tag notification. 
See #2168 sub-task 3.
![image](https://user-images.githubusercontent.com/3894242/49481386-bc6cd800-f7f8-11e8-8094-741c259ede59.png)
