### PR TITLE
Fix web interface key import from keychain - part of #2129

### DIFF
--- a/mailpile/plugins/keylookup/__init__.py
+++ b/mailpile/plugins/keylookup/__init__.py
@@ -209,12 +209,15 @@ def lookup_crypto_keys(session, address,
             # has been successfully imported to the keychain.
             if key_id in known_keys_list or get and key_id in get:
                 found_keys[key_id]['on_keychain'] = True
-                
+
+            # Check if key is already in the VCard for the specified address.
             if address in found_keys[key_id]['vcards']:
-                 for k in found_keys[key_id]['vcards'][address]['keys']:
-                    if k['fingerprint'] == key_id:
-                        found_keys[key_id]['in_vcards'] = True
-               
+                vcard = found_keys[key_id]['vcards'][address]
+                if 'keys' in vcard:
+                     for k in vcard['keys']:
+                         if k['fingerprint'] == key_id:
+                             found_keys[key_id]['in_vcards'] = True
+
         # This updates and sorts ordered_keys in place. This will magically
         # also update the data on the viewable event, because Python.
         ordered_keys[:] = found_keys.values()
@@ -302,8 +305,8 @@ class KeyImport(Command):
             # a user id containing that address, so when it is imported to
             # VCards, the VCard for that address will list the key.
             # The 'in_vcards' attribute is relevant to the given address only.
-            k['in_vcards'] = True
-                                  
+            for k in result:
+                k['in_vcards'] = True
             # Previous crypto evaluations may now be out of date, so we
             # clear the cache so users can see results right away.
             ClearParseCache(pgpmime=True)

--- a/shared-data/default-theme/html/partials/hidden.html
+++ b/shared-data/default-theme/html/partials/hidden.html
@@ -124,8 +124,8 @@
         <% } %>
       </a>
       <div class="searchkey-result-actions right">
-        <% if (on_keychain) { %>
-        <i>{{_("This key is on your key chain.")}}</i>
+        <% if (on_keychain && in_vcards) { %>
+        <i>{{_("This key is available for use.")}}</i>
 {#
         <select name="contact-key" class="crypto-key-policy" data-fingerprint="<%= fingerprint %>">
           <option value="true" selected="selected">{{_("Use This Key")}}</option>


### PR DESCRIPTION
In #2129 some problems were reported with importing a key that has been added to the keychain using gpg from the command line, so that it is on the keychain but is not in Mailpile's VCards. A key must be identified on a VCard for a contact in order for Mailpile to use it for encryption. PR #2182 fixed the underlying problem with the `crypto/keyimport` CLI command, but there was still a problem when such a key import was attempted from the web interface. Specifically, a search for keys using the addressee's email address found the key, but the `Import Key` button was not displayed so the user had no way to import it.

The problem with the web interface was that `template-crypto-encryption-key` in `shared-data/default-theme/html/partials/hidden.html` checks the result of the `crypto/keylookup` command for the attribute `on_keychain`. If it is `True`, the `Import Key` button is not displayed.

This PR fixes that problem by adding an attribute `in_vcards`. If either `on_keychain` or in`_vcards` is `False`, the Import Key button is displayed.

This is a little more complicated than it at first appears (of course!!) because it is then necessary to set the `in_vcards` attribute to the correct value when a key is first found by `crypto/keylookup` and then to update it (and `on_keychain`) when the key is imported by `crypto/keyimport`.

The message after a successful import, `This key is on your key chain` was changed to `This key is available for use` to more accurately reflect what has happened. (In any case a casual user may notknow what a keychain is!)

There is a conceptual issue in that `in_vcards` is not a property of the key alone, it depends on the email address for which a key is required. The key could conceivably be in some VCard other than the one that is relevant. Nevertheless, this fix appears to work satisfactorily.
