### PR TITLE
Run futurize --stage1

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import getopt
 import gettext
 import locale
@@ -141,12 +142,12 @@ def Interact(session):
                     result = Action(session, opt, arg)
                     session.ui.block()
                     session.ui.display_result(result)
-                except UsageError, e:
+                except UsageError as e:
                     session.fatal_error(unicode(e))
-                except UrlRedirectException, e:
+                except UrlRedirectException as e:
                     session.fatal_error('Tried to redirect to: %s' % e.url)
     except EOFError:
-        print
+        print()
     finally:
         session.ui.unblock(force=True)
 
@@ -181,7 +182,7 @@ class InteractCommand(Command):
         splash = HelpSplash(session, 'help', []).run()
         motd = MessageOfTheDay(session, 'motd', ['--noupdate']).run()
         session.ui.display_result(splash)
-        print  # FIXME: This is a hack!
+        print()  # FIXME: This is a hack!
         session.ui.display_result(motd)
 
         Interact(session)
@@ -246,7 +247,7 @@ fail in unexpected ways. If it breaks you get to keep both pieces!
                                    'please log in!'))
         HealthCheck(session, None, []).run()
         config.prepare_workers(session)
-    except AccessError, e:
+    except AccessError as e:
         session.ui.error('Access denied: %s\n' % e)
         sys.exit(1)
 
@@ -282,7 +283,7 @@ fail in unexpected ways. If it breaks you get to keep both pieces!
                     session.ui.display_result(Action(
                         session, args[0], ' '.join(args[1:]).decode('utf-8')))
 
-        except (getopt.GetoptError, UsageError), e:
+        except (getopt.GetoptError, UsageError) as e:
             session.fatal_error(unicode(e))
 
         if (not allopts) and (not a1) and (not a2):

--- a/mailpile/config/base.py
+++ b/mailpile/config/base.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import io
 import json
 import os
@@ -264,7 +265,7 @@ def RuledContainer(pcls):
                             config.set(section, key, value, comment)
             for key in keys:
                 if hasattr(self[key], 'as_config'):
-                    if isinstance(self[key], (list,)):
+                    if isinstance(self[key], list):
                         # If a list is marked public, we export all items
                         self[key].as_config(config=config)
                     else:
@@ -814,6 +815,6 @@ if __name__ == "__main__":
     session.ui.block()
 
     result = doctest.testmod(optionflags=doctest.ELLIPSIS)
-    print '%s' % (result, )
+    print('%s' % (result, ))
     if result.failed:
         sys.exit(1)

--- a/mailpile/config/defaults.py
+++ b/mailpile/config/defaults.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 APPVER = "1.0.0rc5"
 ABOUT = """\
 Mailpile.py              a tool             Copyright 2013-2018, Mailpile ehf
@@ -260,7 +261,7 @@ if __name__ == "__main__":
     import mailpile.config.defaults
     from mailpile.config.base import ConfigDict
 
-    print '%s' % (ConfigDict(_name='mailpile',
+    print('%s' % (ConfigDict(_name='mailpile',
                              _comment='Base configuration',
                              _rules=mailpile.config.defaults.CONFIG_RULES
-                             ).as_config_bytes(), )
+                             ).as_config_bytes(), ))

--- a/mailpile/config/manager.py
+++ b/mailpile/config/manager.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import cPickle
 import io
@@ -150,7 +151,7 @@ class ConfigManager(ConfigDict):
         if not os.path.exists(self.workdir):
             if session:
                 session.ui.notify(_('Creating: %s') % self.workdir)
-            os.makedirs(self.workdir, mode=0700)
+            os.makedirs(self.workdir, mode=0o700)
             mailpile.platforms.RestrictReadAccess(self.workdir)
 
         # Once acquired, lock_workdir is only released by process termination.
@@ -1300,10 +1301,10 @@ class ConfigManager(ConfigDict):
                         except socket.error:
                             port_in_use = False
                         if port_in_use:
-                            raise socket.error, errno.EADDRINUSE
+                            raise socket.error(errno.EADDRINUSE)
                     config.http_worker = HttpWorker(config.background, sspec)
                     config.http_worker.start()
-                except socket.error, e:
+                except socket.error as e:
                     if e[0] == errno.EADDRINUSE:
                         session.ui.error(
                             _('Port %s:%s in use by another Mailpile or program'
@@ -1462,7 +1463,7 @@ class ConfigManager(ConfigDict):
             for w in worker_list:
                 if w and w.isAlive():
                     if config.sys.debug and wait:
-                        print 'Waiting for %s' % w
+                        print('Waiting for %s' % w)
                     w.quit(join=wait)
 
         # Flush the mailbox cache (queues save worker jobs)
@@ -1474,7 +1475,7 @@ class ConfigManager(ConfigDict):
             save_worker = config.save_worker
             config.save_worker = config.dumb_worker
         if config.sys.debug:
-            print 'Waiting for %s' % save_worker
+            print('Waiting for %s' % save_worker)
 
         from mailpile.postinglist import PLC_CACHE_FlushAndClean
         PLC_CACHE_FlushAndClean(config.background, keep=0)
@@ -1483,7 +1484,7 @@ class ConfigManager(ConfigDict):
 
         if config.sys.debug:
             # Hooray!
-            print 'All stopped!'
+            print('All stopped!')
 
     def _unlocked_notify_workers_config_changed(config):
         worker_list = config._unlocked_get_all_workers()
@@ -1567,6 +1568,6 @@ if __name__ == "__main__":
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={'cfg': cfg,
                                           'session': session})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/config/paths.py
+++ b/mailpile/config/paths.py
@@ -9,7 +9,7 @@ except ImportError:
     AppDirs = None
 
 
-def _ensure_exists(path, mode=0700):
+def _ensure_exists(path, mode=0o700):
     if not os.path.exists(path):
         head, tail = os.path.split(path)
         _ensure_exists(head)

--- a/mailpile/config/validators.py
+++ b/mailpile/config/validators.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import socket
 import re
@@ -367,6 +368,6 @@ if __name__ == "__main__":
     import doctest
     import sys
     result = doctest.testmod(optionflags=doctest.ELLIPSIS)
-    print '%s' % (result, )
+    print('%s' % (result, ))
     if result.failed:
         sys.exit(1)

--- a/mailpile/conn_brokers.py
+++ b/mailpile/conn_brokers.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Connection brokers facilitate & manage incoming and outgoing connections.
 #
 # The idea is that code actually tells us what it wants to do, so we can
@@ -716,7 +717,7 @@ class MasterBroker(BaseConnectionBroker):
 def DisableUnbrokeredConnections():
     """Enforce the use of brokers EVERYWHERE!"""
     def CreateConnWarning(*args, **kwargs):
-        print '*** socket.create_connection used without a broker ***'
+        print('*** socket.create_connection used without a broker ***')
         traceback.print_stack()
         raise IOError('FIXME: Please use within a broker context')
     monkey_clean_scc = CreateConnWarning
@@ -999,7 +1000,7 @@ def SslWrapOnlyOnce(org_sslwrap, sock, *args, **kwargs):
                 kwargs['server_hostname'] = ctx.address[0]
             sock = org_sslwrap(sock, *args, **kwargs)
             ctx.encryption = _explain_encryption(sock)
-        except (socket.error, IOError, ssl.SSLError, ssl.CertificateError), e:
+        except (socket.error, IOError, ssl.SSLError, ssl.CertificateError) as e:
             ctx.error = '%s' % e
             raise
     return sock
@@ -1046,6 +1047,6 @@ else:
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/crypto/aes_utils.py
+++ b/mailpile/crypto/aes_utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This is a compatibility wrapper for using whatever AES library is handy.
 # By default we support Cryptography and pyCrypto, with a preference for
 # Cryptography.
@@ -148,7 +149,7 @@ if __name__ == "__main__":
     r1 = results[0]
     for result in results[1:]:
         if r1[1] != result[1]:
-            print '%s != %s' % (r1, result)
+            print('%s != %s' % (r1, result))
             okay = False
     assert(okay)
 
@@ -162,4 +163,4 @@ if __name__ == "__main__":
     decrypted = aes_ctr_decrypt(legacy_key, legacy_nonce, legacy_ct)
     assert(legacy_data == decrypted)
 
-    print "ok"
+    print("ok")

--- a/mailpile/crypto/autocrypt_utils.py
+++ b/mailpile/crypto/autocrypt_utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (C) 2018 Jack Dodds
 # This code is part of Mailpile and is hereby released under the
 # Gnu Affero Public Licence v.3 - see ../../COPYING and ../../AGPLv3.txt.
@@ -300,9 +301,9 @@ if __name__ == "__main__":
     default_file = os.path.dirname(os.path.abspath(__file__))
     default_file = os.path.abspath(default_file + '/../tests/data/pub.key')
 
-    print
-    print 'Default key file:', default_file
-    print
+    print()
+    print('Default key file:', default_file)
+    print()
 
     key_file_path = raw_input('Enter key file path or <Enter> for default: ')
     if key_file_path == '':
@@ -319,16 +320,16 @@ if __name__ == "__main__":
     with open(key_file_path, 'r') as keyfile:
         keydata = bytearray( keyfile.read() )
 
-    print 'Key length:', len(keydata)
+    print('Key length:', len(keydata))
 
     newkey, u, i = get_minimal_PGP_key(
         keydata, user_id=user_id, subkey_id=subkey_id, binary_out=True)
 
-    print 'User ID:', u
-    print 'Subkey ID:', i
-    print 'Minimal key length:', len(newkey)
+    print('User ID:', u)
+    print('Subkey ID:', i)
+    print('Minimal key length:', len(newkey))
     key_file_path += '.min.gpg'
-    print 'Minimal key output file:', key_file_path
+    print('Minimal key output file:', key_file_path)
 
     with open(key_file_path, 'w') as keyfile:
         keyfile.write(newkey)

--- a/mailpile/crypto/gpgi.py
+++ b/mailpile/crypto/gpgi.py
@@ -1,4 +1,5 @@
 #coding:utf-8
+from __future__ import print_function
 import os
 import string
 import sys
@@ -389,7 +390,7 @@ class GnuPGRecordParser:
         pass  # FIXME
 
     def parse_unknown(self, line):
-        print "Unknown line with code '%s'" % (line,)
+        print("Unknown line with code '%s'" % (line,))
 
     def parse_none(line):
         pass
@@ -490,7 +491,7 @@ class StreamWriter(Thread):
             output.close()
         except:
             if not self.partial_write_ok:
-                print '%s: %s bytes left' % (self, total)
+                print('%s: %s bytes left' % (self, total))
                 traceback.print_exc()
         finally:
             self.state = 'done'
@@ -575,7 +576,7 @@ class GnuPG:
         if self.session:
             self.session.debug(msg.rstrip())
         else:
-            print '%s' % str(msg).rstrip()
+            print('%s' % str(msg).rstrip())
 
     def _debug_none(self, msg):
         pass
@@ -644,7 +645,7 @@ class GnuPG:
                 if which in binaries:
                     args.insert(1, "--%s=%s" % (setting, binaries[which]))
                 else:
-                    print 'wtf: %s not in %s' % (which, binaries)
+                    print('wtf: %s not in %s' % (which, binaries))
 
         if (not self.use_agent) or will_send_passphrase:
             if version < (1, 5):
@@ -780,7 +781,7 @@ class GnuPG:
                 if thr.isAlive():
                     thr.join(timeout=15)
                     if thr.isAlive() and tries > 1:
-                        print 'WARNING: Failed to reap thread %s' % thr
+                        print('WARNING: Failed to reap thread %s' % thr)
 
     def parse_status(self, line, *args):
         self.debug('<<STATUS<< %s' % line)
@@ -1162,7 +1163,7 @@ class GnuPG:
                 found = set()
         else:
             # Could be PGP packet header. Check for sequence of legal headers.
-            while skip < len(segment) and body_len <> -1:
+            while skip < len(segment) and body_len != -1:
                 # Check this packet header.
                 prev_partial = partial
                 ptag, hdr_len, body_len, partial = (
@@ -1203,12 +1204,12 @@ class GnuPG:
 
                 dec_start += hdr_len + body_len
                 skip = dec_start
-                if is_base64 and body_len <> -1:
+                if is_base64 and body_len != -1:
                     enc_start, enc_end, skip = self.base64_segment(dec_start,
                                         dec_start + 6, 0, line_len, line_end )
                     segment = base64.b64decode(data[enc_start:enc_end])
 
-            if is_base64 and body_len <> -1 and skip <> len(segment):
+            if is_base64 and body_len != -1 and skip != len(segment):
                 # End of last packet does not match end of data.
                 found = set()
         return found
@@ -1693,7 +1694,7 @@ class GnuPGExpectScript(threading.Thread):
         except TimedOut:
             timebox[0] = 0
             self.gnupg.debug('Timed out')
-            print 'Boo! %s not found in %s' % (exp, self.before)
+            print('Boo! %s not found in %s' % (exp, self.before))
             raise
 
     def run_script(self, proc, script):

--- a/mailpile/crypto/keyinfo.py
+++ b/mailpile/crypto/keyinfo.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 import traceback
 

--- a/mailpile/crypto/mime.py
+++ b/mailpile/crypto/mime.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # These are methods to do with MIME and crypto, implementing PGP/MIME.
 
 import re
@@ -237,7 +238,7 @@ def UnwrapMimeCrypto(part, protocols=None, psi=None, pei=None, charsets=None,
 
             # Is there a Memory-Hole force-display part?
             pl = part.get_payload()
-            if hdrs and isinstance(pl, (list, )):
+            if hdrs and isinstance(pl, list):
                 if (pl[0]['content-type'].startswith('text/rfc822-headers;')
                         and 'protected-headers' in pl[0]['content-type']):
                     # Parse these headers as well and override the top level,
@@ -800,6 +801,6 @@ if __name__ == "__main__":
     #        we don't have such tests. :-(
 
     results = doctest.testmod(optionflags=doctest.ELLIPSIS)
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/crypto/records.py
+++ b/mailpile/crypto/records.py
@@ -113,6 +113,8 @@ Detailed search keyword stats:
           (sample size: ~300k emails)
 
 """
+from __future__ import print_function
+from __future__ import absolute_import
 import binascii
 import hashlib
 import os
@@ -120,7 +122,7 @@ import struct
 import time
 import threading
 
-from aes_utils import getrandbits, aes_ctr_encrypt, aes_ctr_decrypt
+from .aes_utils import getrandbits, aes_ctr_encrypt, aes_ctr_decrypt
 
 
 class _SimpleList(object):
@@ -259,7 +261,7 @@ class EncryptedRecordStore(_SimpleList):
         # rest is pseudorandom crap.
         with self._lock:
             self._iv_seed += 1
-            self._iv_seed %= 0x1000000000000L
+            self._iv_seed %= 0x1000000000000
             if (self._iv_seed % 123456) == 0:
                 self._write_header()
 
@@ -734,7 +736,7 @@ class EncryptedDict(object):
     def __getitem__(self, key):
         try:
             keyset, (rpos, rdata) = self.load_record(key)
-        except ValueError, msg:
+        except ValueError as msg:
             raise KeyError('%s: %s' % (key, msg))
         return self.rdata_value(rdata)
 
@@ -795,7 +797,7 @@ class EncryptedIntDict(EncryptedDict):
 if __name__ == '__main__':
     import random
 
-    print 'Creating EncryptedDict...'
+    print('Creating EncryptedDict...')
     eid = EncryptedIntDict('/tmp/test.aes', 'this is my secret key',
                            shard_size=25, overwrite=True)
     eid['hello'] = 99
@@ -807,7 +809,7 @@ if __name__ == '__main__':
     except (ValueError, struct.error):
         pass
     assert(list(eid.keys()) == ['hello'])
-    assert(list(eid.values()) == [99L])
+    assert(list(eid.values()) == [99])
 
     for size in (16, 50, 100, 200, 400, 800, 1600):
         er = EncryptedBlobStore('/tmp/tmp.aes', 'this is my secret key',
@@ -850,7 +852,7 @@ if __name__ == '__main__':
            % (done - t0, (done - t0) / count))
     er.close()
 
-    print 'Creating EncryptedDict...'
+    print('Creating EncryptedDict...')
     ed = EncryptedDict('/tmp/test.aes', 'another secret key',
                        shard_size=(count * 2), min_shards=2, overwrite=True)
 
@@ -883,7 +885,7 @@ if __name__ == '__main__':
         except KeyError:
             pass
         except AssertionError:
-            print 'FAILED, GOT: %s => %s' % (i, ed.get(str(i)))
+            print('FAILED, GOT: %s => %s' % (i, ed.get(str(i))))
     done = time.time()
     print ('10k dict reads in %.2f (%.8f s/op)\n -- reads=%s lf=%s'
            % (done - t0, (done - t0) / count, ed.reads, ed.load_factor))

--- a/mailpile/crypto/state.py
+++ b/mailpile/crypto/state.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #. Common crypto state and structure
 import copy
 
@@ -47,7 +48,7 @@ class CryptoInfo(dict):
 
     def _set_status(self, value):
         if value not in self.STATUSES:
-            print 'Bogus status for %s: %s' % (type(self), value)
+            print('Bogus status for %s: %s' % (type(self), value))
             raise ValueError('Invalid status: %s' % value)
         self._status = value
         self.mix_bubbles()
@@ -57,7 +58,7 @@ class CryptoInfo(dict):
             raise KeyError('Invalid key: %s' % item)
         if item == "status":
             if value not in self.STATUSES:
-                print 'Bogus status for %s: %s' % (type(self), value)
+                print('Bogus status for %s: %s' % (type(self), value))
                 raise ValueError('Invalid value for %s: %s' % (key, value))
             if self._status is None:  # Capture initial value
                 self._status = value

--- a/mailpile/crypto/streamer.py
+++ b/mailpile/crypto/streamer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # This is code to stream data to or from encrypted storage. If the invoking
 # code us correctly written, it should be able to work with data far in
@@ -267,9 +268,9 @@ class IOCoprocess(object):
             try:
                 self._proc, self._fd = self._popen(command, fd, long_running)
             except:
-                print 'Popen(%s, %s, %s)' % (command, fd, long_running)
+                print('Popen(%s, %s, %s)' % (command, fd, long_running))
                 traceback.print_exc()
-                print
+                print()
                 raise
         else:
             self._proc, self._fd = None, fd
@@ -295,10 +296,10 @@ class IOCoprocess(object):
                     while proc.poll() is None:
                         time.sleep(0.01)
                         if count == 4:
-                            print 'TERM => %s' % proc
+                            print('TERM => %s' % proc)
                             proc.terminate()
                         elif count > 9:
-                            print 'KILL => %s' % proc
+                            print('KILL => %s' % proc)
                             proc.kill()
                             break
                         count += 1
@@ -773,7 +774,7 @@ class DecryptingStreamer(InputCoprocess):
     def verify(self, testing=False, _raise=None):
         if self.close() != 0:
             if testing:
-                print 'Close returned nonzero'
+                print('Close returned nonzero')
             if _raise:
                 raise _raise('Non-zero exit code from coprocess')
             return False
@@ -782,31 +783,31 @@ class DecryptingStreamer(InputCoprocess):
             mac = mac_sha256(self.mep_mutated, self.inner_sha.digest())
             if self.expected_inner_sha256 != mac:
                 if testing:
-                    print 'Inner %s != %s' % (self.expected_inner_sha256, mac)
+                    print('Inner %s != %s' % (self.expected_inner_sha256, mac))
                 if _raise:
                     raise _raise('Invalid inner SHA256')
                 return False
         elif self.expected_inner_md5sum:
             if self.expected_inner_md5sum != self.inner_md5.hexdigest():
                 if testing:
-                    print 'Inner %s != %s' % (self.expected_inner_md5sum,
-                                              self.inner_md5.hexdigest())
+                    print('Inner %s != %s' % (self.expected_inner_md5sum,
+                                              self.inner_md5.hexdigest()))
                 if _raise:
                     raise _raise('Invalid inner MD5 sum')
                 return False
         elif testing and not self.expected_inner_md5sum:
-            print 'No inner MD5 sum or SHA256 expected'
+            print('No inner MD5 sum or SHA256 expected')
 
         if self.expected_outer_sha256:
             mac = mac_sha256(self.mep_mutated, self.outer_sha.digest())
             if self.expected_outer_sha256 != mac:
                 if testing:
-                    print 'Outer %s != %s' % (self.expected_outer_sha256, mac)
+                    print('Outer %s != %s' % (self.expected_outer_sha256, mac))
                 if _raise:
                     raise _raise('Invalid outer SHA256')
                 return False
         elif testing and not self.expected_outer_sha256:
-            print 'No outer SHA256 expected'
+            print('No outer SHA256 expected')
         return True
 
     def _mk_data_filter(self, fd, cb, ecb):
@@ -1054,8 +1055,8 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
         try:
             for fd in fdpair2:
                 if fd not in fdpair1:
-                    print 'Probably have an FD leak at %s!' % where
-                    print 'Verify with: lsof -g %s' % os.getpid()
+                    print('Probably have an FD leak at %s!' % where)
+                    print('Verify with: lsof -g %s' % os.getpid())
                     import time
                     time.sleep(900)
                     return False
@@ -1075,7 +1076,7 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
     except OSError:
         pass
 
-    print 'Test the IOFilter in write mode'
+    print('Test the IOFilter in write mode')
     with open('/tmp/iofilter.tmp', 'w') as bfd:
         with IOFilter(bfd, counter) as iof:
             iof.writer().write('Hello world!')
@@ -1084,7 +1085,7 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
     _assert(bc[0], 12)
     _assert(fdcheck('IOFilter in write mode'))
 
-    print 'Test the IOFilter in read mode'
+    print('Test the IOFilter in read mode')
     bc[0] = 0
     with open('/tmp/iofilter.tmp', 'r') as bfd:
         with IOFilter(bfd, counter) as iof:
@@ -1093,7 +1094,7 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
             _assert(bc[0], 12)
     _assert(fdcheck('IOFilter in read mode'))
 
-    print 'Test the IOFilter in incomplete read mode'
+    print('Test the IOFilter in incomplete read mode')
     bc[0] = 0
     with open('/dev/urandom', 'r') as bfd:
         with IOFilter(bfd, counter) as iof:
@@ -1102,7 +1103,7 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
     _assert(len(data) == 4096)
     _assert(fdcheck('IOFilter in incomplete read mode'))
 
-    print 'Test the ReadLineIOFilter in incomplete read mode'
+    print('Test the ReadLineIOFilter in incomplete read mode')
     bc[0], daemonlogline = 0, ''
     with open('/etc/passwd', 'r') as bfd:
         with IOFilter(bfd, counter) as iof:
@@ -1114,7 +1115,7 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
     _assert('daemon' in daemonlogline, msg='daemon in %s' % daemonlogline)
     _assert(fdcheck('ReadLineIOFilter in incomplete read mode'))
 
-    print 'Null decryption test, sha256 verification only'
+    print('Null decryption test, sha256 verification only')
     outer_mac_sha256 = '7982970534e089b839957b7e174725ce1878731ed6d700766e59cb16f1c25e27'
     with open('/tmp/iofilter.tmp', 'rb') as bfd:
         with DecryptingStreamer(bfd,
@@ -1125,7 +1126,7 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
             _assert(ds.verify(testing=True))
     _assert(fdcheck('Decrypting test, sha256 verification'))
 
-    print 'Legacy (MEP v1) decryption test'
+    print('Legacy (MEP v1) decryption test')
     for legacy in (LEGACY_TEST_1, LEGACY_TEST_2):
         lfd = StringIO.StringIO(legacy)
         with PartialDecryptingStreamer([], lfd,
@@ -1139,16 +1140,16 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
                 _assert(plaintext, LEGACY_PLAINTEXT)
                 _assert(ds.verify(testing=True))
             except AssertionError:
-                print 'command=%s' % ds.command
-                print 'stderr=%s' % ds.stderr
-                print 'key=%s [%s]\n%s' % (LEGACY_TEST_KEY, ds.mep_mutated, legacy)
+                print('command=%s' % ds.command)
+                print('stderr=%s' % ds.stderr)
+                print('key=%s [%s]\n%s' % (LEGACY_TEST_KEY, ds.mep_mutated, legacy))
                 raise
 
     for cipher in ('none', 'broken', 'aes-128-ctr', 'aes-256-cbc'):
       for filter_sha256 in (True, False):
         for delim in (True, False):
-            print ('Encryption test, cipher=%s, delim=%s, filter_sha256=%s'
-                   ) % (cipher, delim, filter_sha256)
+            print(('Encryption test, cipher=%s, delim=%s, filter_sha256=%s'
+                   ) % (cipher, delim, filter_sha256))
 
             fn = '/tmp/enc-%s-%s-%s.tmp' % (cipher, delim, filter_sha256)
             with open(fn, 'wb') as fd:
@@ -1180,7 +1181,7 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
             _assert(fdcheck('Encrypted data, delimited=%s' % delim))
 
             t1 = time.time()
-            print 'Decryption test, delim=%s' % delim
+            print('Decryption test, delim=%s' % delim)
             with open(fn, 'rb') as bfd:
                 new_data = ''
                 for ms in encrypted:
@@ -1199,8 +1200,8 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
                 try:
                     _assert(data, new_data)
                 except:
-                    print 'OLD %d bytes vs. NEW %d bytes: \n%s\n' % (
-                        len(data), len(new_data), new_data[-100:])
+                    print('OLD %d bytes vs. NEW %d bytes: \n%s\n' % (
+                        len(data), len(new_data), new_data[-100:]))
                     raise
             _assert(fdcheck('Decrypting test, delimited=%s' % delim))
             t2 = time.time()
@@ -1209,10 +1210,10 @@ U2FsdGVkX19U8G7SKp8QygUusdHZThlrLcI04+jZ9U5kwfsw7bJJ2721dwgIpCUh
 
         # Cleanup
         os.unlink(fn)
-      print
+      print()
 
     _assert(len(DETECTED_OBSOLETE_FORMATS) > 0)
-    print 'Obsolete formats detected: %s' % DETECTED_OBSOLETE_FORMATS
+    print('Obsolete formats detected: %s' % DETECTED_OBSOLETE_FORMATS)
 
     os.unlink('/tmp/iofilter.tmp')
     _assert(fdcheck('All done'))

--- a/mailpile/eventlog.py
+++ b/mailpile/eventlog.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import datetime
 import json
@@ -326,7 +327,7 @@ class EventLog(object):
                     return False
             else:
                 # Unknown keywords match nothing...
-                print 'Unknown keyword: `%s=%s`' % (okw, rule)
+                print('Unknown keyword: `%s=%s`' % (okw, rule))
                 return False
         return True
 

--- a/mailpile/httpd.py
+++ b/mailpile/httpd.py
@@ -278,7 +278,7 @@ class HttpRequestHandler(SimpleXMLRPCRequestHandler):
                     else:
                         message = None
                 code, msg = 200, "OK"
-            except IOError, e:
+            except IOError as e:
                 mimetype = 'text/plain'
                 if e.errno == 2:
                     code, msg = 404, "File not found"
@@ -331,7 +331,7 @@ class HttpRequestHandler(SimpleXMLRPCRequestHandler):
             else:
                 raise ValueError(_('Unknown content-type'))
 
-        except (IOError, ValueError), e:
+        except (IOError, ValueError) as e:
             self.send_full_response(self.server.session.ui.render_page(
                 config, self._ERROR_CONTEXT,
                 body='POST geborked: %s' % e,
@@ -501,7 +501,7 @@ class HttpRequestHandler(SimpleXMLRPCRequestHandler):
                                     header_list=http_headers,
                                     cachectrl=cachectrl)
 
-        except UrlRedirectException, e:
+        except UrlRedirectException as e:
             return self.send_http_redirect(e.url)
         except SuppressHtmlOutput:
             return None

--- a/mailpile/index/base.py
+++ b/mailpile/index/base.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import json
 import random
@@ -123,7 +124,7 @@ class BaseIndex(MessageInfoConstants):
             except (IOError, OSError, KeyError, ValueError, IndexError):
                 if 'sources' in self.config.sys.debug:
                     traceback.print_exc()
-                    print 'WARNING: %s not found' % msg_ptr
+                    print('WARNING: %s not found' % msg_ptr)
             yield (msg_ptr, mbox, fd)
 
     ### ... ################################################################
@@ -242,6 +243,6 @@ if __name__ == '__main__':
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/index/mailboxes.py
+++ b/mailpile/index/mailboxes.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import email.parser
 import json
 import traceback
@@ -53,7 +54,7 @@ class MailboxIndex(BaseIndex):
                       if ptr in self.ptrset]
             result.reverse()
         else:
-            print 'FIXME! %s: search %s' % (self, terms)
+            print('FIXME! %s: search %s' % (self, terms))
             result = []
         return SearchResultSet(self, terms, result, [])
 
@@ -63,6 +64,6 @@ if __name__ == '__main__':
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/index/msginfo.py
+++ b/mailpile/index/msginfo.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mailpile.i18n import gettext as _
 from mailpile.i18n import ngettext as _n
 
@@ -35,6 +36,6 @@ if __name__ == '__main__':
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/index/search.py
+++ b/mailpile/index/search.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 
 from mailpile.i18n import gettext as _
@@ -66,6 +67,6 @@ if __name__ == '__main__':
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/mail_source/imap.py
+++ b/mailpile/mail_source/imap.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This implements our IMAP mail source. It has been tested against the
 # following IMAP implementations:
 #
@@ -124,7 +125,7 @@ def _parse_imap(reply):
             if isinstance(dline, (str, unicode)):
                 m = IMAP_TOKEN.match(dline)
             else:
-                print 'WARNING: Unparsed IMAP response data: %s' % (dline,)
+                print('WARNING: Unparsed IMAP response data: %s' % (dline,))
                 m = None
             if m:
                 token = m.group(0)
@@ -329,7 +330,7 @@ class SharedImapConn(threading.Thread):
                     break
             send_line('DONE')
             # Note: We let the IDLE response drop on the floor, don't care.
-        except (socket.error, OSError), val:
+        except (socket.error, OSError) as val:
             raise self._conn.abort('socket error: %s' % val)
 
     def quit(self):
@@ -1217,7 +1218,7 @@ if __name__ == "__main__":
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={'session': session,
                                           'imap_config': config.sources.imap})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)
 
@@ -1230,11 +1231,11 @@ if __name__ == "__main__":
         config.sources.imap.password = password
         imap = ImapMailSource(session, config.sources.imap)
         with imap.open(throw=IMAP_IOError) as conn:
-            print '%s' % (conn.list(), )
+            print('%s' % (conn.list(), ))
         mbx = SharedImapMailbox(config, imap, mailbox_path='INBOX')
-        print '%s' % list(mbx.iterkeys())
+        print('%s' % list(mbx.iterkeys()))
         for key in args:
             info, payload = mbx.get(key)
-            print '%s(%d bytes) = %s\n%s' % (mbx.get_msg_ptr('0000', key),
+            print('%s(%d bytes) = %s\n%s' % (mbx.get_msg_ptr('0000', key),
                                              mbx.get_msg_size(key),
-                                             info, payload)
+                                             info, payload))

--- a/mailpile/mailboxes/macmail.py
+++ b/mailpile/mailboxes/macmail.py
@@ -78,7 +78,7 @@ class MacMaildir(mailbox.Mailbox):
             self.remove(key)
         except KeyError:
             pass
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.ENOENT:
                 raise
 

--- a/mailpile/mailboxes/mbox.py
+++ b/mailpile/mailboxes/mbox.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import errno
 import mailbox
 import os
@@ -81,7 +82,7 @@ class MailpileMailbox(mailbox.mbox):
                 if not os.path.exists(self._path):
                     raise NoSuchMailboxError(self._path)
                 self._file = self._get_fd()
-            except IOError, e:
+            except IOError as e:
                 if e.errno == errno.ENOENT:
                     raise NoSuchMailboxError(self._path)
                 elif e.errno == errno.EACCES:
@@ -416,7 +417,7 @@ Content-Length: %(length)s
              tf.write("\n")
         tf.flush()
         if verbose or wait:
-            print 'Temporary mailbox in: %s' % tf.name
+            print('Temporary mailbox in: %s' % tf.name)
         if wait:
             raw_input('Press ENTER to continue...')
 
@@ -431,8 +432,8 @@ Content-Length: %(length)s
              f2size = len(mmbx.get_file_by_ptr(msg_ptr, from_=True).read())
              result = 'ok' if (o_size == c_size == f_size == f2size) else 'BAD'
              if verbose or result != 'ok':
-                 print "%-3.3s [%s/%s/%s] %s ?= %s ?= %s ?= %s" % (
-                     result, i, key, msg_ptr, o_size, c_size, f_size, f2size)
+                 print("%-3.3s [%s/%s/%s] %s ?= %s ?= %s ?= %s" % (
+                     result, i, key, msg_ptr, o_size, c_size, f_size, f2size))
              if result != 'ok':
                  problems += 1
              tests += 1
@@ -472,7 +473,7 @@ Content-Length: %(length)s
                 print('ok  Message %s found in new location' % msg_ptr)
 
         # This is formatted to look like doctest results...
-        print 'TestResults(failed=%d, attempted=%d)' % (problems, tests)
+        print('TestResults(failed=%d, attempted=%d)' % (problems, tests))
         if wait:
             raw_input('Tests finished. Press ENTER to clean up...')
 

--- a/mailpile/mailboxes/pop3.py
+++ b/mailpile/mailboxes/pop3.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 try:
     import cStringIO as StringIO
 except ImportError:
@@ -379,16 +380,16 @@ if __name__ == "__main__":
 
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)
 
     if len(sys.argv) > 1:
         mbx = MailpileMailbox(*MailpileMailbox.parse_path(None, sys.argv[1]))
-        print 'Status is: %s' % (mbx.stat(), )
-        print 'Downloading mail and listing subjects, hit CTRL-C to quit'
+        print('Status is: %s' % (mbx.stat(), ))
+        print('Downloading mail and listing subjects, hit CTRL-C to quit')
         for msg in mbx:
-            print msg['subject']
+            print(msg['subject'])
             time.sleep(2)
 
 else:

--- a/mailpile/mailboxes/wervd.py
+++ b/mailpile/mailboxes/wervd.py
@@ -131,7 +131,7 @@ class MailpileMailbox(UnorderedPicklable(mailbox.Maildir, editable=True)):
         try:
             tmpdir = os.path.join(self._path, 'tmp')
             if not os.path.exists(tmpdir):
-                os.mkdir(tmpdir, 0700)
+                os.mkdir(tmpdir, 0o700)
             if key:
                 es = EncryptingStreamer(key,
                                         dir=tmpdir, name='WERVD',

--- a/mailpile/mailutils/addresses.py
+++ b/mailpile/mailutils/addresses.py
@@ -1,5 +1,6 @@
 # vim: set fileencoding=utf-8 :
 #
+from __future__ import print_function
 import base64
 import copy
 import quopri
@@ -203,7 +204,7 @@ class AddressHeaderParser(list):
                 try:
                     return base64.b64decode(''.join(data.split())+'===').decode(cs)
                 except TypeError:
-                    print 'FAILED TO B64DECODE: %s' % data
+                    print('FAILED TO B64DECODE: %s' % data)
                     return data
             else:
                 return quopri.decodestring(data, header=True).decode(cs)
@@ -379,6 +380,6 @@ if __name__ == "__main__":
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/mailutils/emails.py
+++ b/mailpile/mailutils/emails.py
@@ -2,6 +2,7 @@
 #
 # FIXME: Refactor this monster into mailpile.mailutils.*
 #
+from __future__ import print_function
 import base64
 import copy
 import email.header
@@ -809,7 +810,7 @@ class Email(object):
                     removed.append(msg_ptr)
             except (IOError, OSError, ValueError, AttributeError) as e:
                 failed.append(msg_ptr)
-                print 'FIXME: Could not delete %s: %s' % (msg_ptr, e)
+                print('FIXME: Could not delete %s: %s' % (msg_ptr, e))
 
         if allow_deletion and not failed and not kept:
             self.index.delete_msg_at_idx_pos(session, self.msg_idx_pos,
@@ -1439,8 +1440,8 @@ class Email(object):
                         pgpdata[1]['crypto']['signature'] = si
                         pgpdata[2]['data'] = ''
 
-                    except Exception, e:
-                        print e
+                    except Exception as e:
+                        print(e)
 
             if decrypt:
                 if part['type'] in ('pgpbegin', 'pgptext'):
@@ -1498,6 +1499,6 @@ if __name__ == "__main__":
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/mailutils/generator.py
+++ b/mailpile/mailutils/generator.py
@@ -55,6 +55,7 @@
 
 
 """Classes to generate plain text from a message object tree."""
+from __future__ import print_function
 
 __all__ = ['Generator', 'DecodedGenerator']
 
@@ -143,7 +144,7 @@ class Generator:
             ufrom = msg.get_unixfrom()
             if not ufrom:
                 ufrom = 'From nobody ' + time.ctime(time.time())
-            print >> self._fp, ufrom + self._NL,
+            print(ufrom + self._NL, end=' ', file=self._fp)
         self._write(msg)
 
     def clone(self, fp):
@@ -203,14 +204,14 @@ class Generator:
 
     def _write_headers(self, msg):
         for h, v in msg.items():
-            print >> self._fp, '%s:' % h,
+            print('%s:' % h, end=' ', file=self._fp)
             if self._maxheaderlen == 0:
                 # Explicit no-wrapping
-                print >> self._fp, v + self._NL,
+                print(v + self._NL, end=' ', file=self._fp)
             elif isinstance(v, Header):
                 # Header instances know what to do
                 hdr = v.encode().replace('\n', self._NL)
-                print >> self._fp, hdr + self._NL,
+                print(hdr + self._NL, end=' ', file=self._fp)
             elif _is8bitstring(v):
                 # If we have raw 8bit data in a byte string, we have no idea
                 # what the encoding is.  There is no safe way to split this
@@ -218,7 +219,7 @@ class Generator:
                 # ascii split, but if it's multibyte then we could break the
                 # string.  There's no way to know so the least harm seems to
                 # be to not split the string and risk it being too long.
-                print >> self._fp, v + self._NL,
+                print(v + self._NL, end=' ', file=self._fp)
             else:
                 # Header's got lots of smarts, so use it.  Note that this is
                 # fundamentally broken though because we lose idempotency when
@@ -227,9 +228,9 @@ class Generator:
                 # fixed bug 1974.  Either way, we lose.
                 hdr = Header(v, maxlinelen=self._maxheaderlen, header_name=h
                              ).encode().replace('\n', self._NL)
-                print >> self._fp, hdr + self._NL,
+                print(hdr + self._NL, end=' ', file=self._fp)
         # A blank line always separates headers from body
-        print >> self._fp, self._NL,
+        print(self._NL, end=' ', file=self._fp)
 
     #
     # Handlers for writing types and subtypes
@@ -282,9 +283,9 @@ class Generator:
                 preamble = fcre.sub('>From ', msg.preamble)
             else:
                 preamble = msg.preamble
-            print >> self._fp, preamble + self._NL,
+            print(preamble + self._NL, end=' ', file=self._fp)
         # dash-boundary transport-padding CRLF
-        print >> self._fp, '--' + boundary + self._NL,
+        print('--' + boundary + self._NL, end=' ', file=self._fp)
         # body-part
         if msgtexts:
             self._fp.write(msgtexts.pop(0))
@@ -293,13 +294,13 @@ class Generator:
         # --> CRLF body-part
         for body_part in msgtexts:
             # delimiter transport-padding CRLF
-            print >> self._fp, self._NL + '--' + boundary + self._NL,
+            print(self._NL + '--' + boundary + self._NL, end=' ', file=self._fp)
             # body-part
             self._fp.write(body_part)
         # close-delimiter transport-padding
         self._fp.write(self._NL + '--' + boundary + '--')
         if msg.epilogue is not None:
-            print >> self._fp, self._NL,
+            print(self._NL, end=' ', file=self._fp)
             if self._mangle_from_:
                 epilogue = fcre.sub('>From ', msg.epilogue)
             else:
@@ -403,12 +404,12 @@ class DecodedGenerator(Generator):
         for part in msg.walk():
             maintype = part.get_content_maintype()
             if maintype == 'text':
-                print >> self, part.get_payload(decode=True) + self._NL,
+                print(part.get_payload(decode=True) + self._NL, end=' ', file=self)
             elif maintype == 'multipart':
                 # Just skip this
                 pass
             else:
-                print >> self, self._fmt % {
+                print(self._fmt % {
                     'type': part.get_content_type(),
                     'maintype': part.get_content_maintype(),
                     'subtype': part.get_content_subtype(),
@@ -417,18 +418,18 @@ class DecodedGenerator(Generator):
                                             '[no description]'),
                     'encoding': part.get('Content-Transfer-Encoding',
                                          '[no encoding]'),
-                    } + self._NL,
+                    } + self._NL, end=' ', file=self)
 
 
 # Helper
-_width = len(repr(sys.maxint-1))
+_width = len(repr(sys.maxsize-1))
 _fmt = '%%0%dd' % _width
 
 
 def _make_boundary(text=None):
     # Craft a random boundary.  If text is given, ensure that the chosen
     # boundary doesn't appear in the text.
-    token = random.randrange(sys.maxint)
+    token = random.randrange(sys.maxsize)
     boundary = ('=' * 15) + (_fmt % token) + '=='
     if text is None:
         return boundary

--- a/mailpile/mailutils/header.py
+++ b/mailpile/mailutils/header.py
@@ -5,6 +5,7 @@ It includes fixes that have not been ported to py2
 https://bugs.python.org/issue1079
 
 """
+from __future__ import print_function
 import binascii
 import email.quoprimime
 import email.base64mime
@@ -121,6 +122,6 @@ if __name__ == "__main__":
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/mailutils/headerprint.py
+++ b/mailpile/mailutils/headerprint.py
@@ -1,5 +1,6 @@
 # vim: set fileencoding=utf-8 :
 #
+from __future__ import print_function
 import re
 from mailpile.util import md5_hex
 
@@ -108,6 +109,6 @@ if __name__ == "__main__":
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/mailutils/html.py
+++ b/mailpile/mailutils/html.py
@@ -1,5 +1,6 @@
 # vim: set fileencoding=utf-8 :
 #
+from __future__ import print_function
 import lxml.etree
 import lxml.html
 import lxml.html.clean
@@ -121,6 +122,6 @@ if __name__ == "__main__":
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/mailutils/safe.py
+++ b/mailpile/mailutils/safe.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import email
 import email.errors
 import email.message
@@ -167,6 +168,6 @@ if __name__ == '__main__':
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/mailutils/vcal.py
+++ b/mailpile/mailutils/vcal.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 import icalendar
 from datetime import datetime

--- a/mailpile/packing.py
+++ b/mailpile/packing.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import struct
 import time
 import zlib
@@ -75,7 +76,7 @@ def PackLongList(longs):
     1416
     """
     packed = struct.pack('<' + 'q' * len(longs), *longs)
-    if (len(packed) > 8 * 15) or (longs[0] == 0xffffffffffffffffL):
+    if (len(packed) > 8 * 15) or (longs[0] == 0xffffffffffffffff):
         return ('\xff\xff\xff\xff\xff\xff\xff\xff' + zlib.compress(packed))
     else:
         return packed
@@ -257,6 +258,6 @@ if __name__ == '__main__':
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/platforms.py
+++ b/mailpile/platforms.py
@@ -163,9 +163,9 @@ def RestrictReadAccess(path):
     """
     # FIXME: Windows code goes here!
     if os.path.isdir(path):
-        os.chmod(path, 0700)
+        os.chmod(path, 0o700)
     else:
-        os.chmod(path, 0600)
+        os.chmod(path, 0o600)
 
 
 def RandomListeningPort(count=1, host='127.0.0.1'):

--- a/mailpile/plugins/__init__.py
+++ b/mailpile/plugins/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Plugins!
 import imp
 import inspect
@@ -130,7 +131,7 @@ class PluginManager(object):
             for subdir in self._listdir(pdir):
                 pname = subdir.lower()
                 if pname in self.BUILTIN:
-                    print 'Cannot overwrite built-in plugin: %s' % pname
+                    print('Cannot overwrite built-in plugin: %s' % pname)
                     continue
                 if pname in self.DISCOVERED and not update:
                     # FIXME: this is lame
@@ -145,7 +146,7 @@ class PluginManager(object):
                         # FIXME: Need more sanity checks
                         self.DISCOVERED[pname] = (plug_path, manifest)
                 except (ValueError, AssertionError):
-                    print 'Bad manifest: %s' % manifest_filename
+                    print('Bad manifest: %s' % manifest_filename)
                 except (OSError, IOError):
                     pass
 
@@ -177,7 +178,7 @@ class PluginManager(object):
         sys.modules[full_name].__file__ = full_path
         with i18n_disabled:
             with open(full_path, 'r') as mfd:
-                exec mfd.read() in sys.modules[full_name].__dict__
+                exec(mfd.read(), sys.modules[full_name].__dict__)
 
     def _load(self, plugin_name, process_manifest=False, config=None):
         full_name = 'mailpile.plugins.%s' % plugin_name
@@ -218,7 +219,7 @@ class PluginManager(object):
                 raise
             except:
                 traceback.print_exc(file=sys.stderr)
-                print 'FIXME: Loading %s failed, tell user!' % full_name
+                print('FIXME: Loading %s failed, tell user!' % full_name)
                 if full_name in sys.modules:
                     del sys.modules[full_name]
                 return None
@@ -230,7 +231,7 @@ class PluginManager(object):
                 self._process_manifest_pass_two(*spec)
                 self._process_startup_hooks(*spec)
         else:
-            print 'Unrecognized plugin: %s' % plugin_name
+            print('Unrecognized plugin: %s' % plugin_name)
             return self
 
         if plugin_name not in self.LOADED:
@@ -250,7 +251,7 @@ class PluginManager(object):
                 package = 'mailpile.plugins.%s' % plugin_name
                 _, manifest = self.DISCOVERED[plugin_name]
 
-                if sys.modules.has_key(package):
+                if package in sys.modules:
                     for method_name in self._mf_path(manifest,
                                                      'lifecycle', 'shutdown'):
                         method = self._get_method(package, method_name)
@@ -268,8 +269,8 @@ class PluginManager(object):
                 try:
                     if spec[0] not in failed:
                         process(*spec)
-                except Exception, e:
-                    print 'Failed to process manifest for %s: %s' % (spec[0], e)
+                except Exception as e:
+                    print('Failed to process manifest for %s: %s' % (spec[0], e))
                     failed.append(spec[0])
                     traceback.print_exc()
         return self
@@ -410,7 +411,7 @@ class PluginManager(object):
                                             'html/' + tpath,
                                             filename)
                 else:
-                    print 'FIXME: Un-routable URL in manifest %s' % url
+                    print('FIXME: Un-routable URL in manifest %s' % url)
 
         # Register email content/crypto hooks
         s = self
@@ -491,8 +492,8 @@ class PluginManager(object):
             where = '->'.join(['%s:%s' % ('/'.join(stack[i][1].split('/')[-2:]),
                                           stack[i][2])
                               for i in reversed(range(2, len(stack)-1))])
-            print ('FIXME: Deprecated use of %s at %s (issue #547)'
-                   ) % (stack[1][3], where)
+            print(('FIXME: Deprecated use of %s at %s (issue #547)'
+                   ) % (stack[1][3], where))
 
     def _rhtf(self, kw_hash, term, function):
         if term in kw_hash:

--- a/mailpile/plugins/backups.py
+++ b/mailpile/plugins/backups.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import cStringIO
 import datetime
 import gzip
@@ -239,7 +240,7 @@ class RestoreBackup(Command):
 
         for keyfile in ('gnupg-pubkeys.asc.gze', 'gnupg-privkeys.asc.gze'):
             gze = backup_zip.read(keyfile)
-            print 'DATA: %s' % gze
+            print('DATA: %s' % gze)
             self._gnupg().import_keys(_gunzip(_decrypt(gze, config)))
 
 

--- a/mailpile/plugins/compose.py
+++ b/mailpile/plugins/compose.py
@@ -933,7 +933,7 @@ class Sendit(CompositionCommand):
             # Encryption related failures are fatal, don't retry
             except (KeyLookupError,
                     EncryptionFailureError,
-                    SignatureFailureError), exc:
+                    SignatureFailureError) as exc:
                 message = unicode(exc)
                 session.ui.warning(message)
                 if hasattr(exc, 'missing_keys'):
@@ -1029,15 +1029,15 @@ class Update(CompositionCommand):
                                                    sent=emails)
             else:
                 return self._edit_messages(emails, new=False, tag=False)
-        except KeyLookupError, kle:
+        except KeyLookupError as kle:
             return self._error(_('Missing encryption keys'),
                                info={'missing_keys': kle.missing})
-        except EncryptionFailureError, efe:
+        except EncryptionFailureError as efe:
             # This should never happen, should have been prevented at key
             # lookup!
             return self._error(_('Could not encrypt message'),
                                info={'to_keys': efe.to_keys})
-        except SignatureFailureError, sfe:
+        except SignatureFailureError as sfe:
             # FIXME: We assume signature failures happen because
             # the key is locked. Are there any other reasons?
             return self._error(_('Could not sign message'),

--- a/mailpile/plugins/core.py
+++ b/mailpile/plugins/core.py
@@ -331,7 +331,7 @@ class Rescan(Command):
                         session.ui.mark('\n')
                     if not session.ui.interactive:
                         break
-        except (KeyboardInterrupt, subprocess.CalledProcessError), e:
+        except (KeyboardInterrupt, subprocess.CalledProcessError) as e:
             return {
                 'aborted': True,
                 'messages': msg_count,
@@ -1007,9 +1007,9 @@ class ListDir(Command):
                             file_list.extend(ls(p))
                         else:
                             file_list.append(lsf(p))
-            except (socket.error, socket.gaierror), e:
+            except (socket.error, socket.gaierror) as e:
                 return self._error(_('Network error: %s') % e)
-            except (OSError, IOError, UnicodeDecodeError), e:
+            except (OSError, IOError, UnicodeDecodeError) as e:
                 errors += 1
 
         if errors and not file_list:
@@ -1058,7 +1058,7 @@ class ChangeDir(ListDir):
             os.chdir(FilePath.unalias(
                         os.path.expanduser(args.pop(0).encode('utf-8'))))
             return ListDir.command(self, args=['.'])
-        except (OSError, IOError, UnicodeEncodeError), e:
+        except (OSError, IOError, UnicodeEncodeError) as e:
             return self._error(_('Failed to change directories: %s') % e)
 
 

--- a/mailpile/plugins/crypto_gnupg.py
+++ b/mailpile/plugins/crypto_gnupg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import datetime
 import re
@@ -302,7 +303,7 @@ class GPGKeySign(Command):
         try: signingkey = args.pop(0)
         except: signingkey = self.data.get("signingkey", None)
 
-        print keyid
+        print(keyid)
         if not keyid:
             return self._error("You must supply a keyid", None)
         rv = self._gnupg().sign_key(keyid, signingkey)
@@ -475,7 +476,7 @@ class GPGCheckKeys(Search):
             Command.CommandResult.__init__(self, *args, **kwargs)
 
         def as_text(self):
-            if not isinstance(self.result, (dict,)):
+            if not isinstance(self.result, dict):
                 return ''
             if self.result.get('details'):
                 message = '%s.\n - %s' % (self.message, '\n - '.join(

--- a/mailpile/plugins/cryptostate.py
+++ b/mailpile/plugins/cryptostate.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mailpile.i18n import gettext as _
 from mailpile.i18n import ngettext as _n
 from mailpile.plugins import PluginManager
@@ -35,10 +36,10 @@ def meta_kw_extractor(index, msg_mid, msg, msg_size, msg_ts, **kwargs):
                 kw.add('%s:sig' % keyinfo[-16:].lower())
 
         if 'cryptostate' in index.config.sys.debug:
-            print 'part status(=%s): enc=%s sig=%s' % (msg_mid,
+            print('part status(=%s): enc=%s sig=%s' % (msg_mid,
                 part.encryption_info.get('status'),
                 part.signature_info.get('status')
-            )
+            ))
 
         # This is OpenPGP-specific
         if (part.encryption_info.get('protocol') == 'openpgp'
@@ -79,7 +80,7 @@ def meta_kw_extractor(index, msg_mid, msg, msg_size, msg_ts, **kwargs):
             kw.add('%s:in' % tag[0]._key)
 
     if 'cryptostate' in index.config.sys.debug:
-        print 'part crypto state(=%s): %s' % (msg_mid, ','.join(list(kw)))
+        print('part crypto state(=%s): %s' % (msg_mid, ','.join(list(kw))))
 
     return list(kw)
 

--- a/mailpile/plugins/html_magic.py
+++ b/mailpile/plugins/html_magic.py
@@ -161,7 +161,7 @@ class HttpProxyGetRequest(Command):
             with ConnBroker.context(need=conn_need, reject=conn_reject) as ctx:
                 session.ui.mark('Getting: %s' % url)
                 response = urlopen(url, data=None, timeout=timeout)
-        except HTTPError, e:
+        except HTTPError as e:
             response = e
 
         data = response.read()

--- a/mailpile/plugins/keylookup/nicknym.py
+++ b/mailpile/plugins/keylookup/nicknym.py
@@ -1,5 +1,6 @@
 #coding:utf-8
 
+from __future__ import print_function
 from mailpile.commands import Command
 from mailpile.conn_brokers import Master as ConnBroker
 from mailpile.plugins import PluginManager
@@ -201,4 +202,4 @@ _plugins.register_commands(NicknymRefreshKeys)
 
 if __name__ == "__main__":
     n = Nicknym()
-    print n.get_key("varac@bitmask.net")
+    print(n.get_key("varac@bitmask.net"))

--- a/mailpile/plugins/oauth.py
+++ b/mailpile/plugins/oauth.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 import time
 import traceback
@@ -219,7 +220,7 @@ class OAuth2(TestableWebbable):
         if code:
             username, oname, csrf = state.split('/', 2)
             if not session.ui.valid_csrf_token(csrf):
-                print 'Invalid CSRF token: %s' % csrf
+                print('Invalid CSRF token: %s' % csrf)
                 raise AccessError('Invalid CSRF token')
 
             oname, ocfg = self.GetOAuthConfig(config, oname=oname)

--- a/mailpile/plugins/plugins.py
+++ b/mailpile/plugins/plugins.py
@@ -65,7 +65,7 @@ class LoadPlugin(mailpile.commands.Command):
                     config.sys.plugins.append(plugin)
                 else:
                     raise ValueError('Loading failed')
-            except Exception, e:
+            except Exception as e:
                 self._ignore_exception()
                 return self._error(_('Failed to load plugin: %s') % plugin,
                                    info={'failed': plugin})

--- a/mailpile/plugins/search.py
+++ b/mailpile/plugins/search.py
@@ -390,7 +390,7 @@ class SearchResults(dict):
                                              ][cid] = self._address(cid=cid)
             problem = None
 
-        except Exception, e:
+        except Exception as e:
             if problem:
                 problem += ' ' + _('Message may be corrupt!')
             details = {

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import datetime
 import os
@@ -497,7 +498,7 @@ class SetupGetEmailSettings(TestableWebbable):
         elif sockettype.lower() == 'starttls':
             servertype += '_tls'
         else:
-            print 'FIXME/SOURCE: %s/%s' % (sockettype, servertype)
+            print('FIXME/SOURCE: %s/%s' % (sockettype, servertype))
         return servertype.lower()
 
     def _route_proto(self, outsrv):
@@ -508,7 +509,7 @@ class SetupGetEmailSettings(TestableWebbable):
         elif sockettype.lower() == 'starttls':
             servertype += 'tls'
         else:
-            print 'FIXME/ROUTE: %s/%s' % (sockettype, servertype)
+            print('FIXME/ROUTE: %s/%s' % (sockettype, servertype))
         return servertype.lower()
 
     def _rank(self, entry):
@@ -1186,7 +1187,7 @@ class SetupTestRoute(TestableWebbable):
         except OSError:
             error_info = {'error': _('Invalid command'),
                           'invalid_command': True}
-        except SendMailError, e:
+        except SendMailError as e:
             error_info = {'error': e.message,
                           'sendmail_error': True}
             error_info.update(e.error_info)

--- a/mailpile/plugins/vcard_mork.py
+++ b/mailpile/plugins/vcard_mork.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2.7
 #coding:utf-8
+from __future__ import print_function
 import sys
 import re
 import getopt
@@ -170,8 +171,8 @@ class MorkImporter(VCardImporter):
             rowkey = row.id + "/" + table.scope
 
         if rowkey in table.rows:
-            print >>stderr, "ERROR: duplicate rowid/scope %s" % rowkey
-            print >>stderr, cells
+            print("ERROR: duplicate rowid/scope %s" % rowkey, file=stderr)
+            print(cells, file=stderr)
 
         table.rows[rowkey] = row
 
@@ -298,8 +299,8 @@ class MorkImporter(VCardImporter):
                 continue
 
             # Syntax error
-            print >>stderr, "ERROR: syntax error while parsing MORK file"
-            print >>stderr, "context[%d]: %s" % (index, sub[:40])
+            print("ERROR: syntax error while parsing MORK file", file=stderr)
+            print("context[%d]: %s" % (index, sub[:40]), file=stderr)
             index += 1
 
         # Return the database
@@ -363,6 +364,6 @@ if __name__ == "__main__":
 
     m = MorkImporter(filename=filename)
     m.load()
-    print m.get_contacts(data)
+    print(m.get_contacts(data))
 else:
     _plugins.register_vcard_importers(MorkImporter)

--- a/mailpile/plugins/webterminal.py
+++ b/mailpile/plugins/webterminal.py
@@ -91,7 +91,7 @@ class TerminalCommand(Command):
             return self._error(_('Command disallowed'), result={})
         try:
             result = Action(session, command, args)
-        except Exception, e:
+        except Exception as e:
             result = {"error": "Fail!"}
 
         return self._success(_('Ran a command'), result={

--- a/mailpile/postinglist.py
+++ b/mailpile/postinglist.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import random

--- a/mailpile/safe_popen.py
+++ b/mailpile/safe_popen.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # This module implements a safer version of Popen and a safe wrapper around
 # os.pipe(), to avoid deadlocks caused by file descriptors being shared
@@ -121,7 +122,7 @@ class Safe_Popen(Unsafe_Popen):
 
         # This lets us inject Popen args into libraries
         preset = self._preset_args()
-        if preset: print 'PRESET[%s]: %s' % (args, preset)
+        if preset: print('PRESET[%s]: %s' % (args, preset))
         cwd = preset.get('cwd', cwd)
         env = preset.get('env', env)
         stdin = preset.get('stdin', stdin)

--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import cStringIO
 import email
 import random
@@ -462,7 +463,7 @@ class MailIndex(BaseIndex):
                 session.ui.mark(_('%s: Checking: %s'
                                   ) % (mailbox_idx, mailbox_fn))
                 mbox.update_toc()
-        except (IOError, OSError, ValueError, NoSuchMailboxError), e:
+        except (IOError, OSError, ValueError, NoSuchMailboxError) as e:
             if 'rescan' in session.config.sys.debug:
                 session.ui.debug(traceback.format_exc())
             return finito(-1, _('%s: Error opening: %s (%s)'
@@ -1552,7 +1553,7 @@ class MailIndex(BaseIndex):
                             incoming=incoming)
 
         if 'keywords' in self.config.sys.debug:
-            print 'KEYWORDS: %s' % keywords
+            print('KEYWORDS: %s' % keywords)
 
         for word in keywords:
             if (word.startswith('__') or
@@ -1871,8 +1872,8 @@ class MailIndex(BaseIndex):
                         return [int(h, 36) for h in gpl_hits]
                     except ValueError:
                         b36re = re.compile('^[a-zA-Z0-9]{1,8}$')
-                        print 'FIXME! BAD HITS: %s => %s' % (term, [
-                            h for h in gpl_hits if not b36re.match(h)])
+                        print('FIXME! BAD HITS: %s => %s' % (term, [
+                            h for h in gpl_hits if not b36re.match(h)]))
                         return [int(h, 36) for h in gpl_hits if b36re.match(h)]
 
         # Replace some GMail-compatible terms with what we really use
@@ -2146,6 +2147,6 @@ if __name__ == '__main__':
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/security.py
+++ b/mailpile/security.py
@@ -6,6 +6,7 @@ security related decisions made by the app, in order to facilitate
 review and testing.
 
 """
+from __future__ import print_function
 import copy
 import hashlib
 import json
@@ -753,6 +754,6 @@ if __name__ == "__main__":
     import doctest
     import sys
     result = doctest.testmod(optionflags=doctest.ELLIPSIS)
-    print '%s' % (result, )
+    print('%s' % (result, ))
     if result.failed:
         sys.exit(1)

--- a/mailpile/tests/data/pgp-data/buildexamples.py
+++ b/mailpile/tests/data/pgp-data/buildexamples.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import email
 import mailbox
@@ -11,7 +12,7 @@ def getProcesses():
             "--sign", "--recipient 0x5AB5B329 --encrypt"]
 
 def runPGP(input, params):
-    print "Running PGP"
+    print("Running PGP")
     params = params.split(" ")
     params.insert(0, "../gpg-keyring/")
     params.insert(0, "--home")
@@ -29,8 +30,8 @@ def genExamples():
 	contents = open("sources/" + source, "r").read()
 	language, charset = source.split(".")
         for process in getProcesses():
-            print "Creating %s mail with %s encoding and %s PGP" % (language,
-                  charset, process)
+            print("Creating %s mail with %s encoding and %s PGP" % (language,
+                  charset, process))
             string = runPGP(contents, process)
             e = email.message_from_string(string)
             e.set_charset(charset)

--- a/mailpile/tests/test_crypto_policy.py
+++ b/mailpile/tests/test_crypto_policy.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mailpile.vcard import MailpileVCard, VCardLine
 from mailpile.tests import MailPileUnittest
 
@@ -29,7 +30,7 @@ class UpdateCryptoPolicyForUserTest(CryptoPolicyBaseTest):
         for policy in ['default', 'none', 'sign', 'sign-encrypt',
                        'encrypt', 'best-effort']:
             r = self.mp.crypto_policy_set('test@test.local', policy)
-            print '%s' % r.as_dict()
+            print('%s' % r.as_dict())
             self.assertEqual('success', r.as_dict()['status'])
 
         for policy in ['anything', 'else']:

--- a/mailpile/tests/test_keylookup.py
+++ b/mailpile/tests/test_keylookup.py
@@ -13,7 +13,7 @@ GPG_MOCK_RETURN = {
         'uids': [{'comment': '', 'name': 'Mailpile!', 'email': 'test@mailpile.is'}],
         'keysize': '4096',
         'keytype_name': 'RSA',
-        'created': datetime.datetime(2014, 06, 22, 02, 37, 23),
+        'created': datetime.datetime(2014, 0o6, 22, 0o2, 37, 23),
         'fingerprint': '08A650B8E2CBC1B02297915DC65626EED13C70DA',
     }
 }

--- a/mailpile/tests/test_search.py
+++ b/mailpile/tests/test_search.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 from nose.tools import assert_equal, assert_less
 
@@ -13,7 +14,7 @@ def checkSearch(query, expected_count=1):
                 assert_equal(results.result['stats']['count'], expected_count)
                 assert_less(float(results.as_dict()["elapsed"]), 0.2)
             except:
-                print 'BAD RESULT:\n%s' % results.as_text()
+                print('BAD RESULT:\n%s' % results.as_text())
                 raise
     TestSearch.description = "Searching for %s" % str(query)
     return TestSearch

--- a/mailpile/ui.py
+++ b/mailpile/ui.py
@@ -471,7 +471,7 @@ class UserInteraction:
                 #                  very strictly in case it somehow came
                 #                  from user data.
                 return env.get_template(fn)
-            except (IOError, OSError, AttributeError), e:
+            except (IOError, OSError, AttributeError) as e:
                 pass
         return None
 
@@ -523,7 +523,7 @@ class UserInteraction:
                 'traceback': traceback.format_exc(),
                 'data': alldata
             })
-        except (TemplateNotFound, TemplatesNotFound), e:
+        except (TemplateNotFound, TemplatesNotFound) as e:
             tpl_esc_names = [escape_html(tn) for tn in tpl_names]
             return self._render_error(cfg, {
                 'error': _('Template not found'),
@@ -531,7 +531,7 @@ class UserInteraction:
                 'data': alldata
             })
         except (TemplateError, TemplateSyntaxError,
-                TemplateAssertionError,), e:
+                TemplateAssertionError,) as e:
             return self._render_error(cfg, {
                 'error': _('Template error'),
                 'details': ('In %s (%s), line %s:\n%s'

--- a/mailpile/urlmap.py
+++ b/mailpile/urlmap.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import cgi
 import time
 from urlparse import parse_qs, urlparse
@@ -104,7 +105,7 @@ class UrlMap:
                          (not method and name == c.SYNOPSIS[1]))]
             if len(match) != 1:
                 raise UsageError('Unknown command: %s' % name)
-        except ValueError, e:
+        except ValueError as e:
             raise UsageError(str(e))
         command = match[0]
 
@@ -650,7 +651,7 @@ class UrlMap:
 
     def print_map_markdown(self):
         """Prints the current URL map to stdout in markdown"""
-        print self.map_as_markdown()
+        print(self.map_as_markdown())
 
 
 class UrlRedirect(Command):
@@ -696,7 +697,7 @@ class HelpUrlMap(Command):
                 html = markdown(str(self.result['urlmap']))
             except:
                 import traceback
-                print traceback.format_exc()
+                print(traceback.format_exc())
                 html = '<pre>%s</pre>' % escape_html(self.result['urlmap'])
             self.result['markdown'] = html
             return Command.CommandResult.as_html(self, *args, **kwargs)
@@ -739,7 +740,7 @@ else:
         results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                                   extraglobs={'urlmap': urlmap,
                                               'request': None})
-        print '%s' % (results, )
+        print('%s' % (results, ))
         if results.failed:
             sys.exit(1)
     else:

--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -2,6 +2,7 @@
 #
 # Misc. utility functions for Mailpile.
 #
+from __future__ import print_function
 import cgi
 import copy
 import ctypes
@@ -165,13 +166,13 @@ def _TracedLock(what, *a, **kw):
     class Wrapper:
         def acquire(self, *args, **kwargs):
             if self.locked():
-                print '==!== Waiting for %s at %s' % (str(lock), WhereAmI(2))
+                print('==!== Waiting for %s at %s' % (str(lock), WhereAmI(2)))
             return lock.acquire(*args, **kwargs)
         def release(self, *args, **kwargs):
             return lock.release(*args, **kwargs)
         def __enter__(self, *args, **kwargs):
             if self.locked():
-                print '==!== Waiting for %s at %s' % (str(lock), WhereAmI(2))
+                print('==!== Waiting for %s at %s' % (str(lock), WhereAmI(2)))
             return lock.__enter__(*args, **kwargs)
         def __exit__(self, *args, **kwargs):
             return lock.__exit__(*args, **kwargs)
@@ -439,7 +440,7 @@ def b36(number):
     return ''.join(reversed(base36))
 
 
-def string_to_rank(text, maxint=sys.maxint):
+def string_to_rank(text, maxint=sys.maxsize):
     """
     Approximate lexographical order with an int. It's accurate near
     the front of the string, but gets fuzzy towards letter 10.
@@ -1188,6 +1189,6 @@ if __name__ == "__main__":
     import doctest
     import sys
     result = doctest.testmod()
-    print '%s' % (result, )
+    print('%s' % (result, ))
     if result.failed:
         sys.exit(1)

--- a/mailpile/vcard.py
+++ b/mailpile/vcard.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import random
 import threading
 import time
@@ -1633,6 +1634,6 @@ if __name__ == "__main__":
         rules=mailpile.config.defaults.CONFIG_RULES)
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={'cfg': cfg})
-    print '%s' % (results, )
+    print('%s' % (results, ))
     if results.failed:
         sys.exit(1)

--- a/mailpile/workers.py
+++ b/mailpile/workers.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 import random
 import threading
@@ -130,7 +131,7 @@ class Cron(threading.Thread):
                     self.last_run = time.time()
                     self.running = name
                     task()
-                except Exception, e:
+                except Exception as e:
                     self.schedule[name][4] = 'FAILED'
                     self.session.ui.error(('%s failed in %s: %s'
                                            ) % (name, self.name, e))
@@ -289,14 +290,14 @@ class Worker(threading.Thread):
                     session.report_task_completed(name, task())
                 else:
                     task()
-            except (JobPostponingException), e:
+            except (JobPostponingException) as e:
                 session.ui.debug('Postponing: %s' % name)
                 self.add_task(session, name, task,
                               after=time.time() + e.seconds)
-            except (IOError, OSError), e:
+            except (IOError, OSError) as e:
                 self._failed(session, name, task, e)
                 time.sleep(1)
-            except Exception, e:
+            except Exception as e:
                 self._failed(session, name, task, e)
             finally:
                 self.last_run = time.time()
@@ -397,6 +398,6 @@ if __name__ == "__main__":
     import sys
     result = doctest.testmod(optionflags=doctest.ELLIPSIS,
                              extraglobs={'junk': {}})
-    print '%s' % (result, )
+    print('%s' % (result, ))
     if result.failed:
         sys.exit(1)

--- a/packages/scripts/build-controller.py
+++ b/packages/scripts/build-controller.py
@@ -3,6 +3,7 @@
 FIXME...
 
 """
+from __future__ import print_function
 import getopt
 import os
 import time
@@ -75,7 +76,7 @@ class BuildbotController(object):
         return opts, args
 
     def cmd_hello(self, args):
-        print 'Hello: %s' % ' '.join(args)
+        print('Hello: %s' % ' '.join(args))
         args[:] = []
 
     def cmd_win(self, args):

--- a/packages/scripts/build-desktop.py
+++ b/packages/scripts/build-desktop.py
@@ -5,6 +5,7 @@ build-desktop.py - Checkout and build Mailpile for desktop platforms (win/mac)
 Usage: build-desktop.py [clean] <nightly|release>
 
 """
+from __future__ import print_function
 import os
 import subprocess
 import sys

--- a/packages/scripts/kite-runner.py
+++ b/packages/scripts/kite-runner.py
@@ -4,6 +4,7 @@
 kite-runner.py  - XMLRPC-based script launcher with PageKite integration.
 
 """
+from __future__ import print_function
 import getopt
 import json
 import os

--- a/packages/windows-wix/bin/with-mailpile-env.py
+++ b/packages/windows-wix/bin/with-mailpile-env.py
@@ -11,6 +11,7 @@ import os
 import sys
 import subprocess
 import argparse
+from functools import reduce
 
 locate = (("Mailpile", "mailpile"),
           ("gpg", "bin", "gpg.exe"),

--- a/packages/windows-wix/provide/__main__.py
+++ b/packages/windows-wix/provide/__main__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import os.path
 import time
@@ -13,8 +14,8 @@ logging.basicConfig()
 if 'DEBUG' in os.environ:
     logging.getLogger().setLevel(logging.DEBUG)
 
-import cache
-import default
+from . import cache
+from . import default
 
 package_dir = os.path.dirname(__file__)
 

--- a/packages/windows-wix/provide/cache.py
+++ b/packages/windows-wix/provide/cache.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os.path
 try:
     import urllib2

--- a/packages/windows-wix/provide/default.py
+++ b/packages/windows-wix/provide/default.py
@@ -1,4 +1,5 @@
-import build
+from __future__ import absolute_import
+from . import build
 import importlib
 import glob
 import os.path

--- a/scripts/colorprints.py
+++ b/scripts/colorprints.py
@@ -24,6 +24,7 @@
 # is shifted by a fixed value derived from the MD5 of the original
 # fingerprint.
 #
+from __future__ import print_function
 import datetime
 import os
 import hashlib
@@ -216,63 +217,63 @@ def toangel(slices, fingerprint, copy=True, size=64):
                     '</span>\n'])
 
 if os.getenv('HTTP_METHOD'):
-   print 'Content-Type: text/html'
-   print
-print canvastest
+   print('Content-Type: text/html')
+   print()
+print(canvastest)
 
 fingerprint = "A3C4 F0F9 79CA A22C DBA8  F512 EE8C BC9E 886D DD89"
 cprint = colorprint(fingerprint, md5shift=False)
-print '<b>Channels:</b> ', tohtml(cprint), '<br>'
+print('<b>Channels:</b> ', tohtml(cprint), '<br>')
 
-print '<h4>Channels, +mixing, +sizes, +md5shift</h4>'
-print toangel([[rgb, 1] for mixed, rgb, fg, bg, val, hc in cprint],
-              fingerprint)
-print toangel([[mixed, 1] for mixed, rgb, fg, bg, val, hc in cprint],
-              fingerprint), '<br>'
-print toangel([[mixed, 0.5 + float(val % 32)/64]
+print('<h4>Channels, +mixing, +sizes, +md5shift</h4>')
+print(toangel([[rgb, 1] for mixed, rgb, fg, bg, val, hc in cprint],
+              fingerprint))
+print(toangel([[mixed, 1] for mixed, rgb, fg, bg, val, hc in cprint],
+              fingerprint), '<br>')
+print(toangel([[mixed, 0.5 + float(val % 32)/64]
                 for mixed, rgb, fg, bg, val, hc in cprint],
-              fingerprint)
+              fingerprint))
 cprint = colorprint(fingerprint, md5shift=True)
-print toangel([[mixed, 0.5 + float(val % 32)/64]
+print(toangel([[mixed, 0.5 + float(val % 32)/64]
                 for mixed, rgb, fg, bg, val, hc in cprint],
-              fingerprint), '<br>'
+              fingerprint), '<br>')
 
-print '<h4>1 bit flipped, w/o or with md5shift</h4>'
+print('<h4>1 bit flipped, w/o or with md5shift</h4>')
 fingerprint = "A3C4 F0F8 79CA A22C DBA8  F512 EE8C BC9E 886D DD89"
 cprint = colorprint(fingerprint, md5shift=False)
-print toangel([[mixed, 0.5 + float(val % 32)/64]
+print(toangel([[mixed, 0.5 + float(val % 32)/64]
                 for mixed, rgb, fg, bg, val, hc in cprint],
-              fingerprint)
+              fingerprint))
 cprint = colorprint(fingerprint, md5shift=True)
-print toangel([[mixed, 0.5 + float(val % 32)/64]
+print(toangel([[mixed, 0.5 + float(val % 32)/64]
                 for mixed, rgb, fg, bg, val, hc in cprint],
-              fingerprint), '<br>'
+              fingerprint), '<br>')
 
-print '<h4>New style colorprinting tests: 6x2 palette, channels, mixed</h4>'
+print('<h4>New style colorprinting tests: 6x2 palette, channels, mixed</h4>')
 fingerprint = "A3C4 F0F9 79CA A22C DBA8  F512 EE8C BC9E 886D DD89"
 cprint2 = colorprint2(fingerprint, md5shift=False)
-print toangel([[sixtimestwo, 1.0 - float(rval)/512]
+print(toangel([[sixtimestwo, 1.0 - float(rval)/512]
                 for sixtimestwo, rgb, mixed, val, rval, dr, hc in cprint2],
-              fingerprint)
-print toangel([[rgb, 1.0 - float(rval)/512]
+              fingerprint))
+print(toangel([[rgb, 1.0 - float(rval)/512]
                 for sixtimestwo, rgb, mixed, val, rval, dr, hc in cprint2],
-              fingerprint)
-print toangel([[mixed, 1.0 - float(rval)/512]
+              fingerprint))
+print(toangel([[mixed, 1.0 - float(rval)/512]
                 for sixtimestwo, rgb, mixed, val, rval, dr, hc in cprint2],
-              fingerprint), '<br>'
+              fingerprint), '<br>')
 
-print '<h4>Adding md5shift, checking bit flips</h4>'
+print('<h4>Adding md5shift, checking bit flips</h4>')
 cprint2 = colorprint2(fingerprint, md5shift=True)
-print toangel([[mixed, 1.0 - float(rval)/512]
+print(toangel([[mixed, 1.0 - float(rval)/512]
                 for sixtimestwo, rgb, mixed, val, rval, dr, hc in cprint2],
-              fingerprint)
+              fingerprint))
 fingerprint = "A3C4 F0F8 79CA A22C DBA8  F512 EE8C BC9E 886D DD89"
 cprint2b = colorprint2(fingerprint, md5shift=True)
-print toangel([[mixed, 1.0 - float(rval)/512]
+print(toangel([[mixed, 1.0 - float(rval)/512]
                 for sixtimestwo, rgb, mixed, val, rval, dr, hc in cprint2b],
-              fingerprint), '<br>'
+              fingerprint), '<br>')
 
-print "<hr><h3>More samples (new style, full features)</h3>"
+print("<hr><h3>More samples (new style, full features)</h3>")
 count = 0
 for line in """\
       Key fingerprint = A3C4 F0F9 79CA A22C DBA8  F512 EE8C BC9E 886D DD89
@@ -294,14 +295,14 @@ for line in """\
     if 'Key fingerprint' in line:
         fingerprint = line.split(' = ', 1)[1].strip()
         cprint = colorprint2(fingerprint)
-        print toangel([[mixed, 1.0 - float(rval)/512]
+        print(toangel([[mixed, 1.0 - float(rval)/512]
                        for sixXtwo, rgb, mixed, val, rval, dr, hc in cprint],
-                      fingerprint, copy=False, size=128)
+                      fingerprint, copy=False, size=128))
         count += 1
         if count % 5 == 0:
-            print '<br>'
+            print('<br>')
 
-print '<hr>'
-print 'Generated: %s' % datetime.datetime.now().ctime()
-print '</body></html>'
+print('<hr>')
+print('Generated: %s' % datetime.datetime.now().ctime())
+print('</body></html>')
 

--- a/scripts/create-debian-changelog.py
+++ b/scripts/create-debian-changelog.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2.7
 #This script builds a DCH changelog from the git commit log
+from __future__ import print_function
 from subprocess import check_output, call
 from multiprocessing import Pool
 import os
@@ -17,10 +18,10 @@ def versionFromCommitNo(commitNo):
 head = check_output(["git","rev-parse","HEAD"]).strip()
 revisions = check_output(["git","rev-list",head]).strip().split("\n")
 #Revisions now contains rev identifiers, newest revisions first.
-print "Found %d revisions" % len(revisions)
+print("Found %d revisions" % len(revisions))
 revisions.reverse() #In-place reverse, to make oldest revision first
 #Map the revisions to their log msgs
-print "Mapping revisions to log messages"
+print("Mapping revisions to log messages")
 threadpool = p = Pool(10)
 revLogMsgs = threadpool.map(getLogMessage, revisions)
 #(Re)create the changelog for the first revision (= the oldest one)
@@ -32,6 +33,6 @@ firstCommitMsg = revLogMsgs[0]
 call(["dch","--create","-v",versionFromCommitNo(0),"--package","mailpile",firstCommitMsg])
 #Create the changelog entry for all other commits
 for i in range(1, len(revisions)):
-    print "Generating changelog for revision %d" % i
+    print("Generating changelog for revision %d" % i)
     commitMsg = revLogMsgs[i]
     call(["dch","-v",versionFromCommitNo(i),"--package","mailpile",commitMsg])

--- a/scripts/email-parsing-test.py
+++ b/scripts/email-parsing-test.py
@@ -16,6 +16,7 @@
 # This parser is NOT fully RFC2822 compliant - in particular it will get
 # confused by nested comments (see FIXME in tests below).
 #
+from __future__ import print_function
 import sys
 import traceback
 
@@ -23,10 +24,10 @@ from mailpile.mailutils import AddressHeaderParser as AHP
 
 
 ahp_tests = AHP(AHP.TEST_HEADER_DATA)
-print '_tokens: %s' % ahp_tests._tokens
-print '_groups: %s' % ahp_tests._groups
-print '%s' % ahp_tests
-print 'normalized: %s' % ahp_tests.normalized()
+print('_tokens: %s' % ahp_tests._tokens)
+print('_groups: %s' % ahp_tests._groups)
+print('%s' % ahp_tests)
+print('normalized: %s' % ahp_tests.normalized())
 
 
 headers, header, inheader = {}, None, False
@@ -39,12 +40,12 @@ for line in sys.stdin:
                     try:
                         nv = AHP(val, _raise=True).normalized()
                         if '\\' in nv:
-                            print 'ESCAPED: %s: %s (was %s)' % (hdr, nv, val)
+                            print('ESCAPED: %s: %s (was %s)' % (hdr, nv, val))
                         else:
-                            print '%s' % (nv,)
+                            print('%s' % (nv,))
                     except ValueError:
-                        print 'FAILED: %s: %s -- %s' % (hdr, val,
-                            traceback.format_exc().replace('\n', '  '))
+                        print('FAILED: %s: %s -- %s' % (hdr, val,
+                            traceback.format_exc().replace('\n', '  ')))
             headers, header, inheader = {}, None, False
         elif line[:1] in (' ', '\t') and header:
             headers[header] = headers[header].rstrip() + line[1:]

--- a/scripts/mailpile-test.py
+++ b/scripts/mailpile-test.py
@@ -6,6 +6,7 @@
 # If run with -i as the first argument, it will then drop to an interactive
 # python shell for experimenting and manual testing.
 #
+from __future__ import print_function
 import os
 import sys
 import time
@@ -369,7 +370,7 @@ try:
             say("Tests passed, woot!")
 except:
     sys.stderr.write("\nTests FAILED!\n")
-    print
+    print()
     traceback.print_exc()
 
 
@@ -379,7 +380,7 @@ if '-i' in sys.argv:
     mp.set('prefs/vcard/importers/gravatar/0/active = true')
     mp.set('prefs/vcard/importers/gpg/0/active = true')
     mp._session.ui = ui
-    print '%s' % mp.help_splash()
+    print('%s' % mp.help_splash())
     mp.Interact()
 
 

--- a/scripts/mbox-minimal.py
+++ b/scripts/mbox-minimal.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import sys
 import re
 
@@ -47,7 +48,7 @@ with open(sys.argv[1], 'rb') as fd:
         chunk = fd.read(READS)
 
 
-print ('Done, found %d messages, %d msgids'
-       ) % (len(messages), len([1 for mi in msgids if mi]))
+print(('Done, found %d messages, %d msgids'
+       ) % (len(messages), len([1 for mi in msgids if mi])))
 for i in range(0, 20):
-    print '%d/%d = %s' % (i * 13, messages[i], msgids[i * 13])
+    print('%d/%d = %s' % (i * 13, messages[i], msgids[i * 13]))

--- a/scripts/mk-credits.py
+++ b/scripts/mk-credits.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import os
 import re
 import subprocess
@@ -77,7 +78,7 @@ with open(i18n, 'w') as fd:
                              for n in tlist))
             first = False
         elif translators[lang][1]:
-            print 'wtf: %s' % translators[lang]
+            print('wtf: %s' % translators[lang])
     if not first:
         fd.write('</ul>\n')
 

--- a/scripts/unsent-mail-finder.py
+++ b/scripts/unsent-mail-finder.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python2.7
 
+from __future__ import print_function
 import json
 import sys
 
-print ("""I am an unsent mail finder, due to buggy bug bugness.
+print(("""I am an unsent mail finder, due to buggy bug bugness.
 Run me like so:
 
     cat /home/USER/.mailpile/logs/* | %s
@@ -12,7 +13,7 @@ Run me like so:
 path above to match where your mailpile really is. Sorry this is so
 lame!  If you ran me wrong, press CTRL+C to abort right about now.
 
-""") % sys.argv[0]
+""") % sys.argv[0])
 
 sendits = {}
 for line in sys.stdin.readlines():
@@ -26,8 +27,8 @@ for line in sys.stdin.readlines():
         elif msg.startswith('Connecting'):
             sendits[eid][5]['OK'] = True
   except ValueError:
-    print 'Unparsable: %s' % line
+    print('Unparsable: %s' % line)
 
 for eid, data in sendits.iteritems():
     if 'OK' not in data[5]:
-        print 'On %s, failed to send %s' % (data[0], data[5]['mid'])
+        print('On %s, failed to send %s' % (data[0], data[5]['mid']))

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 import datetime
 import os
 import re
@@ -37,4 +38,4 @@ APPVER = APPVER.replace('1.0.0rc', '0.99.')
 
 
 if __name__ == "__main__":
-    print '%s' % APPVER
+    print('%s' % APPVER)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+from __future__ import print_function
 from datetime import date
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
@@ -57,7 +58,7 @@ pbr.git._find_git_files = _find_git_files
 try:
     assert(0 == subprocess.call(['make', 'clean'], cwd=here))
 except:
-    print "Faild to run 'make clean'. Bailing out."
+    print("Faild to run 'make clean'. Bailing out.")
     exit(1)
 
 
@@ -68,7 +69,7 @@ class Builder(build_py):
         try:
             assert(0 == subprocess.call(['make', 'bdist-prep'], cwd=here))
         except:
-            print "Error building package. Try running 'make'."
+            print("Error building package. Try running 'make'.")
             exit(1)
         else:
             build_py.run(self)

--- a/shared-data/mailpile-gui/mailpile-gui.py
+++ b/shared-data/mailpile-gui/mailpile-gui.py
@@ -17,6 +17,7 @@
 #       a splash-screen. Arguably, more of this logic should be moved
 #       into `mailpile.plugins.gui` so everything is in one place.
 #
+from __future__ import print_function
 import copy
 import fasteners
 import json
@@ -339,7 +340,7 @@ def Main(argv):
         GenerateBootstrap(state, trust_os_path=trust_os_path)]
 
     if '--script' in argv:
-        print '\n'.join(script)
+        print('\n'.join(script))
 
     else:
         # FIXME: We shouldn't need to do this, refactoring upstream

--- a/shared-data/multipile/mailpile-admin.py
+++ b/shared-data/multipile/mailpile-admin.py
@@ -6,6 +6,7 @@
 #  - Start or stop a user's Mailpile (in a screen session)
 #  - Function as a CGI script to start Mailpile and reconfigure Apache
 #
+from __future__ import print_function
 import argparse
 import cgi
 import ConfigParser
@@ -245,7 +246,7 @@ def app_arguments():
 
 
 def usage(ap, reason, code=3):
-    print 'error: %s' % reason
+    print('error: %s' % reason)
     ap.print_usage()
     sys.exit(code)
 
@@ -454,7 +455,7 @@ def _rewritemap(mailpiles):
         user, host, port = details[0:3]
         suffix = ''
         if user in added:
-            print 'WARNING: User %s has multiple Mailpiles!' % user
+            print('WARNING: User %s has multiple Mailpiles!' % user)
             suffix = '.%d' % (added[user] + 1)
 
         rules.append(
@@ -480,8 +481,8 @@ def parse_rewritemap(args, os_settings, mailpiles=None):
                     port = m.group('port')
                     mailpiles['%s:%s' % (host, port)] = [
                         user, host, port, True, None, None]
-    except (OSError, IOError, KeyError), err:
-        print 'WARNING: %s' % err
+    except (OSError, IOError, KeyError) as err:
+        print('WARNING: %s' % err)
     return mailpiles
 
 
@@ -517,12 +518,12 @@ def save_apache_sudoers(os_settings):
 def run_script(args, settings, script):
     for line in script:
         line = line % _escaped(settings)
-        print '==> %s' % line
+        print('==> %s' % line)
         rv = os.system(line)
         if 0 != rv:
-            print '==[ FAILED! Exit code: %s ]==' % rv
+            print('==[ FAILED! Exit code: %s ]==' % rv)
             return
-    print '===[ SUCCESS! ]==='
+    print('===[ SUCCESS! ]===')
 
 
 def _get_mailpiles(args, os_settings, discover=False):
@@ -539,7 +540,7 @@ def list_mailpiles(args):
     mailpiles = _get_mailpiles(args, os_settings, discover=True)
     fmt =  '%-8.8s %6.6s %6.6s %-6.6s %5.5s %s'
     user_counts = {}
-    print fmt % ('USER', 'PID', 'RSS', 'ACCESS', 'PORT', 'URL')
+    print(fmt % ('USER', 'PID', 'RSS', 'ACCESS', 'PORT', 'URL'))
     for hostport in sorted(mailpiles.keys()):
         user, host, port, in_usermap, pid, rss = mailpiles[hostport]
         user_counts[user] = user_counts.get(user, 0) + 1
@@ -549,9 +550,9 @@ def list_mailpiles(args):
                                       os_settings['webroot'], user)
         else:
             url = 'http://%s:%s/' % (host, port)
-        print fmt % (
+        print(fmt % (
             user, pid or '?', rss or '',
-            'apache' if in_usermap else 'direct', port, url)
+            'apache' if in_usermap else 'direct', port, url))
 
 def generate_apache_usermap(app_args, args):
     mailpiles = _get_mailpiles(args, get_os_settings(args))
@@ -696,9 +697,9 @@ def handle_cgi_post():
         settings = get_os_settings(parsed_args)
 
         # Send headers now, so output doesn't confuse Apache
-        print 'Location: %s/%s/' % (settings['webroot'], username)
-        print 'Expires: 0'
-        print
+        print('Location: %s/%s/' % (settings['webroot'], username))
+        print('Expires: 0')
+        print()
 
         # Launch Mailpile?
         rv = launch_mailpile(app_args, parsed_args)
@@ -707,9 +708,9 @@ def handle_cgi_post():
     except:
         parsed_args = app_args.parse_args(['--launch'])
         settings = get_os_settings(parsed_args)
-        print 'Location: %s/?error=yes' % settings['webroot']
-        print 'Expires: 0'
-        print
+        print('Location: %s/?error=yes' % settings['webroot'])
+        print('Expires: 0')
+        print()
 
 
 if __name__ == "__main__":

--- a/shared-data/multipile/mailpile-launcher.py
+++ b/shared-data/multipile/mailpile-launcher.py
@@ -3,6 +3,7 @@
 # IMPORTANT: This script runs as root and is invoked by the web server via sudo.
 #            So it's pretty security-sensitive: simple is better than clever!
 #
+from __future__ import print_function
 DOC="""\
 
 This is a script to launch Mailpile as a specific user.
@@ -26,7 +27,7 @@ MAILPILE_WORK_LOCK = 'workdir-lock'
 
 
 def usage(code, msg=''):
-    print DOC, msg, "\n"
+    print(DOC, msg, "\n")
     sys.exit(code)
 
 


### PR DESCRIPTION
`futurize` produces code that is compatible between Python 2 and 3. `--stage1` leverages `__future__` without requiring any external deps. See: http://python-future.org/automatic_conversion.html

To reproduce the exact same tree, one can run:

```
pip3 install future
echo > mailpile/tests/test_mail_generator.py
futurize --stage1 -nw .
git checkout -- mailpile/tests/test_mail_generator.py
```

This skips `mailpile/tests/test_mail_generator.py` for two reasons: first, it contains a non-UTF8 compliant symbol (by design), second, this file is already Python 3 compatible.

Want to keep these changes as reviewable as possible. I'll send a few more patches (`rfc822` -> `email`, syntax fixes for Python 3 that `futurize` didn't pick up) next.