### PR TITLE
Provide error code with attachment upload err

### DIFF
--- a/shared-data/default-theme/html/jsapi/compose/attachments.js
+++ b/shared-data/default-theme/html/jsapi/compose/attachments.js
@@ -200,7 +200,7 @@ Mailpile.Composer.Attachments.Uploader.init = function(settings) {
         }
       },
       Error: function(up, err) {
-        Mailpile.notification({status: 'error', message: '{{_("Could not upload attachment because")|escapejs}}: ' + err.message });
+        Mailpile.notification({status: 'error', message: '{{_("Could not upload attachment because")|escapejs}}: ' + err.message + ' ' + err.code });
         $('#' + err.file.id).find('b').html('Failed ' + err.code);
         uploader.refresh();
 	Mailpile.notification({status: 'error', message: "Failed to upload " + file.name, event_id: "Upload-" + file.id });


### PR DESCRIPTION
err.message is very generic on attachment upload failure `HTTP Error.`.

Adding `err.code` should give at least something duck-able so the user can troubleshoot more easily.

Fixes #2220