### PR TITLE
don't exit when tor binary check fails

### DIFF
--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -4,6 +4,7 @@ import gettext
 import locale
 import os
 import sys
+import warnings
 import traceback
 
 import mailpile.util
@@ -205,6 +206,7 @@ class WaitCommand(Command):
 
 
 def Main(args):
+    warnings.filterwarnings('error')
     try:
         mailpile.platforms.DetectBinaries(_raise=OSError)
     except OSError as e:
@@ -224,6 +226,9 @@ fail in unexpected ways. If it breaks you get to keep both pieces!
 
 """ % (e, binary.upper(), binary))
         sys.exit(1)
+    except UserWarning as e:
+        sys.stderr.write("Warning: %s\n" %e )
+    warnings.filterwarnings('ignore')
 
     # Enable our connection broker, try to prevent badly behaved plugins from
     # bypassing it.

--- a/mailpile/platforms.py
+++ b/mailpile/platforms.py
@@ -7,11 +7,12 @@ import copy
 import os
 import subprocess
 import sys
-
+import warnings
 
 # This is a cache of discovered binaries and their paths.
 BINARIES = {}
 
+just_warn = ['Tor']
 
 # These are the binaries we want, and the test we use to detect whether
 # they are available/working.
@@ -36,7 +37,7 @@ def DetectBinaries(
     import traceback
 
     global BINARIES
-    if which and use_cache:
+    if which and use_cache: 
         if which in BINARIES:
             return BINARIES[which]
         env_bin = os.getenv('MAILPILE_%s' % which.upper(), '')
@@ -84,7 +85,10 @@ def DetectBinaries(
     if which:
         if _raise not in (None, False):
             if not BINARIES.get(which):
-                raise _raise('%s not found' % which)
+                if which in just_warn:
+                    warnings.warn("warning: %s not found, ignoring!" % which, category=UserWarning)
+                else:
+                    raise _raise('%s not found' % which)
         return BINARIES.get(which)
 
     elif _raise not in (None, False):
@@ -92,7 +96,10 @@ def DetectBinaries(
             if binary in skip:
                 continue
             if not BINARIES.get(binary):
-                raise _raise('%s not found' % binary)
+                if binary in just_warn:
+                    warnings.warn("%s not found, ignoring" % binary,category=UserWarning)
+                else:
+                    raise _raise('%s not found' % binary)
 
     return BINARIES
 


### PR DESCRIPTION
[Make Tor a soft dependency, cope gracefully if tor hangs #2211](https://github.com/mailpile/Mailpile/issues/2211)

This doesn't break the app, as platforms.BINARIES.Tor will be still be false, and thus there will be no way to attempt to load tor.