### PR TITLE
Handle non-password related IMAP login errors appropriately re #1888

### DIFF
--- a/mailpile/mail_source/imap.py
+++ b/mailpile/mail_source/imap.py
@@ -685,8 +685,9 @@ def _connect_imap(session, settings, event,
 
         username = password = ""
         try:
-            error_type = 'auth'
-            error_msg = _('Invalid username or password')
+            error_type = 'login'
+            error_msg = _('IMAP Login error')
+            auth_error_type = auth_error_msg = None
             username = settings.get('username', '').encode('utf-8')
             password = IndirectPassword(
                 session.config,
@@ -695,8 +696,8 @@ def _connect_imap(session, settings, event,
 
             if (settings.get('auth_type', '').lower() == 'oauth2'
                     and 'AUTH=XOAUTH2' in capabilities):
-                error_type = 'oauth2'
-                error_msg = _('Access denied by mail server')
+                auth_error_type = 'oauth2'
+                auth_error_msg = _('Access denied by mail server')
                 token_info = OAuth2.GetFreshTokenInfo(session, username)
                 if not (username and token_info and token_info.access_token):
                     raise ValueError("Missing configuration")
@@ -708,9 +709,27 @@ def _connect_imap(session, settings, event,
                     token_info.access_token = ''
 
             else:
+                auth_error_type = 'auth'
+                auth_error_msg = _('Invalid username or password')
                 ok, data = timed_imap(conn.login, username, password)
-
-        except (IMAP4.error, UnicodeDecodeError, ValueError):
+                
+        except IMAP4.error as save_error:
+            error_str = save_error.__str__()
+            ok, data = False, error_str
+            if auth_error_type:
+                # Is this a password error or some other kind of error?
+                # If the response contains any RFC5530 response code
+                # check for an RFC5530 auth error code, otherwise check for
+                # "password" (case independent) in the response string.
+                if (re.search('\[AUTHENTICATIONFAILED\]|'
+                                '\[AUTHORIZATIONFAILED\]|'
+                                '\[EXPIRED\]',     error_str) or
+                        (not re.search('\[([a-zA-Z]*)\]', error_str) and
+                            re.search('(?i)password', error_str) ) ):
+                    error_type = auth_error_type
+                    error_msg = auth_error_msg
+                    
+        except (UnicodeDecodeError, ValueError):
             ok, data = False, None
         if not ok:
             auth_summary = ''


### PR DESCRIPTION
One of my ISPs sometimes give a response `System error` when an IMAP login is attempted. Usually a second login attempt after five minutes will succeed. (This is password authentication, not OAuth.) But, Mailpile treats this error as a bad IMAP password and will not attempt another IMAP login until the user enters a "correct" password. Confusing, since Mailpile already has the correct password. Assuming that the user has not memorized the password, it is then necessary to `Display Remembered Account Password`, copy it somehow, `Lock Account and Forget Password`, `Unlock Account and Remember Password` and enter the password. Arrrgh!!! This was described in [comments on #1888](https://github.com/mailpile/Mailpile/issues/1888#issuecomment-410461276).

This patch creates a new error type `login` with message `IMAP Login error`. The IMAP response is checked to see if the error is a password error. If not, the `login` error is used. Only if there is a password error is the existing `auth` type error with message `Invalid username or password` used, blocking further login attempts and triggering a request for a new login in the `Notifications` popup.

Unfortunately, detecting a password error is not straightforward. RFC5530 specifies standardized IMAP responses which are always upper case and enclosed by `[ ]`, but adherence to RFC5530 is not required. Of the three ISPs using password (not OAuth) authentication that I use, only one complies wtih RFC5530. In this patch, if the response contains any code in RFC5530 format, the code checks for RFC5530 codes only. If there is no RFC5530 format code in the response, it checks for `PASSWORD` (case independent). This works with the providers that I use.

Conceivably an ISP could respond to a bad user id or password with a non-RFC5530 response that did not contain `PASSWORD`. In that case, the user would see `IMAP Login error` in the notification window every five minutes, which should be enough to alert the user to the problem.