### PR TITLE
Fix  typo in DEV_FAQ

### DIFF
--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -181,7 +181,7 @@ this.](https://github.com/mailpile/Mailpile/issues/160)
 
 Reasons!
 
-Our way may be unusual, but it's kinda awesome once you get used to it
+Our way may be unsual, but it's kinda awesome once you get used to it
 and it wasn't obvious to us how we could get this kind of behaviour from
 one of the standard frameworks.
 

--- a/DEV_FAQ.md
+++ b/DEV_FAQ.md
@@ -181,7 +181,7 @@ this.](https://github.com/mailpile/Mailpile/issues/160)
 
 Reasons!
 
-Our way may be unsual, but it's kinda awesome once you get used to it
+Our way may be unusual, but it's kinda awesome once you get used to it
 and it wasn't obvious to us how we could get this kind of behaviour from
 one of the standard frameworks.
 


### PR DESCRIPTION
Found a small typo on line 184 in DEV_FAQ `unsual`