### PR TITLE
Ignoring docker-compose.yml and variants

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 Dockerfile
 Vagrantfile
+docker-compose.yml
+docker-compose.dev.yml


### PR DESCRIPTION
Including the mini services cluster configuration in the default volume configuration, it allows attackers the ability to modify the docker-compose.yml and potentially go unnoticed when the admin re-deploys the docker-compose.yml micro services cluster.