### PR TITLE
Actually install tor into container [WIP]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV GID 33411
 ENV UID 33411
 
 RUN apt-get update && \
-    apt-get install -y curl apt-transport-https gnupg && \
+    apt-get install -y curl apt-transport-https gnupg tor && \
     curl -s https://packages.mailpile.is/deb/key.asc | apt-key add - && \
     echo "deb https://packages.mailpile.is/deb release main" | tee /etc/apt/sources.list.d/000-mailpile.list && \
     apt-get update && \


### PR DESCRIPTION
Tor is not installed but on lines 14 and 15 there is an attempt made to enable it on container startup which likely will not work correctly but at least now tor will be installed.  Containers are typically single process things but if Mailpile is running `tor --version` as mentioned in #2211 you will need it in the same container.  I don't believe anything calls init.d/systemd inside of containers so there may need to be an alternative path explored. 

The proper method would be to spin up a docker container all on its own and then either do a socket mount between the containers or do a "cross host[container]" connection from the Mailpile container to the Tor container.