### PR TITLE
Fix: add account should not permit duplicate email addresses

### DIFF
--- a/mailpile/plugins/contacts.py
+++ b/mailpile/plugins/contacts.py
@@ -1217,9 +1217,9 @@ class AddProfile(ProfileVCard(AddVCard)):
             all_emails = [ [vcl.value for vcl in vc.get_all('email')] for vc in all_vcards ]
             all_emails = [item for sublist in all_emails for item in sublist]
             
-            new_email = self.data.get('email', [None])[0]
+            all_emails = [email.lower() for email in all_emails]
+            new_email = self.data.get('email', [None])[0].lower()
 
-            
             if new_email in all_emails:
                 raise ValueError("duplicate email address used")
             

--- a/mailpile/plugins/contacts.py
+++ b/mailpile/plugins/contacts.py
@@ -1218,7 +1218,7 @@ class AddProfile(ProfileVCard(AddVCard)):
             all_emails = [item for sublist in all_emails for item in sublist]
             
             all_emails = [email.lower() for email in all_emails]
-            new_email = self.data.get('email', [None])[0].lower()
+            new_email = (self.data.get('email', [None])[0] or vcard.email).lower()
 
             if new_email in all_emails:
                 raise ValueError("duplicate email address used")

--- a/mailpile/plugins/contacts.py
+++ b/mailpile/plugins/contacts.py
@@ -1211,6 +1211,19 @@ class AddProfile(ProfileVCard(AddVCard)):
             # When editing, this doesn't run first, so we invoke it now.
             state = self._before_vcard_create(vcard.kind, [], vcard=vcard)
 
+        if self.name == "profiles/add":
+
+            all_vcards = self.session.config.vcards.find_vcards([], kinds=['profile'])
+            all_emails = [ [vcl.value for vcl in vc.get_all('email')] for vc in all_vcards ]
+            all_emails = [item for sublist in all_emails for item in sublist]
+            
+            new_email = self.data.get('email', [None])[0]
+
+            
+            if new_email in all_emails:
+                raise ValueError("duplicate email address used")
+            
+
         vcard.signature = self.data.get('signature', [''])[0]
         vcard.email = self.data.get('email', [None])[0] or vcard.email
         vcard.fn = self.data.get('name', [None])[0] or vcard.fn

--- a/shared-data/default-theme/html/profiles/account-form.html
+++ b/shared-data/default-theme/html/profiles/account-form.html
@@ -37,17 +37,26 @@
         },
         validate: function() {
           var basic_problems = 0;
+          var dup_email_problems = 0;
           if ($(pf + 'input[name=name]').val() == "" ||
               $(pf + 'input[name=email]').val().indexOf('@') < 0) {
             basic_problems += 1;
             $(pf + 'input[name=name], ' + pf + 'input[name=email]'
               ).on('change', _fpa.validate);
           }
+
+          if (emails.indexOf($(pf + 'input[name=email]').val().toLowerCase()) >= 0) {
+            dup_email_problems += 1;
+            $(pf + 'input[name=name], ' + pf + 'input[name=email]'
+              ).on('change', _fpa.validate);
+          }
+          
           // FIXME: Validate other things too, improve e-mail validation
           //_fpa.display($('.fpa-basics-ok'), basic_problems < 1);
           _fpa.display($('.fpa-basics-bad'), basic_problems > 0);
+          _fpa.display($('.fpa-basics-dup'), dup_email_problems > 0);
           _fpa.display($('#fpa-submit'),
-                       (basic_problems < 1) &&
+                       (basic_problems < 1) && (dup_email_problems < 1) &&
                        (!$(pf + '.fpa-autoconfig').is(':checked')));
         },
         next: function(show) {
@@ -302,6 +311,8 @@
       <span class="icon-signature-unknown fpa-basics-bad right hide" style="padding: 5px; color: #ff5;"
             title="{{_('At least a name and e-mail are required!')}}"></span>
       <span class="icon-checkmark fpa-basics-ok right hide" style="padding: 5px; color: #0d0;"></span>
+      <span class="icon-signature-unknown fpa-basics-dup right hide" style="padding: 5px; color: red;"
+            title="{{_('This email address is already in use!')}}"></span>
     </p>
     <div class="section profile-add-basics {% if ui_open and ui_open != 'basics' %}hide{% endif %}"
          style="position: relative;">

--- a/shared-data/default-theme/html/profiles/index.html
+++ b/shared-data/default-theme/html/profiles/index.html
@@ -220,6 +220,21 @@
 </script>
 {% endif %}
 <script type='text/javascript'>
+  let emails = []
+  
+  {%- if result.profiles|length > 0 %}   
+    {%- if result.rids %}
+      {%- for profile_rid in result.rids %}
+        {%- set p = result.profiles[result.rids[profile_rid]] %}
+         
+          {% for e in p.email %}
+            emails.push("{{ e.email }}")
+          {%- endfor %}
+          
+      {%- endfor %}
+    {% endif %}
+  {% endif %}
+  
   Mailpile.API.logs_events_get({incomplete: true}, EventLog.invoke_callbacks);
 </script>
 {%- endblock %}

--- a/shared-data/default-theme/html/profiles/index.html
+++ b/shared-data/default-theme/html/profiles/index.html
@@ -228,7 +228,7 @@
         {%- set p = result.profiles[result.rids[profile_rid]] %}
          
           {% for e in p.email %}
-            emails.push("{{ e.email }}")
+            emails.push("{{ e.email }}".toLowerCase())
           {%- endfor %}
           
       {%- endfor %}


### PR DESCRIPTION
This PR fixes #2080.

The changes made were:

1. AddProfile in .../mailpile/plugins/contacts.py now checks the new email address before adding a new profile. (We make sure it is not an edit, as suggested in the Issue). So if creating a new profile, the API call fails if the e-mail address already exists.

2. The index.html template collects the accounts passed to it in results.profiles to extract and store the email addresses in a global JS variable.

3. The template .../shared-data/default-theme/html/profiles/account-form.html uses that array to perform an additional validation check on the email entered (we created a new error logo color for this class of errors).


So in summary, both the front end and back end have been updated to fix this issue. Please find screenshots illustrating the fix:


<img width="1232" alt="Screen Shot 2020-12-07 at 5 05 51 PM" src="https://user-images.githubusercontent.com/23176423/101361597-3a648d80-38b0-11eb-8701-915f300084bb.png">


<img width="1335" alt="Screen Shot 2020-12-07 at 5 06 56 PM" src="https://user-images.githubusercontent.com/23176423/101361651-4fd9b780-38b0-11eb-9273-fd5de64a733c.png">
