### PR TITLE
Inline images 1476

### DIFF
--- a/mailpile/mailutils/emails.py
+++ b/mailpile/mailutils/emails.py
@@ -956,14 +956,23 @@ class Email(object):
 
         for part in result.walk():
             content_type = part.get('Content-Type')
+            content_encoding = part.get('Content-Transfer-Encoding')            
 
             if content_type.startswith('text/html'):
                 payload = part.get_payload()
+
+                #if quoted printable, equal signs and line breaks might get in the way. Decode.
+                if content_encoding == 'quoted-printable':
+                    payload = quopri.decodestring(payload)
                 
                 for cid in cid_pattern.findall(payload):
                     if cid in base_64_images:                        
                         payload = payload.replace('cid:' + cid, 'data:{0};base64, {1}'.format(base_64_images[cid][0],base_64_images[cid][1]))
 
+                #encode back if quoted-printable
+                if content_encoding == 'quoted-printable':
+                    payload = quopri.encodestring(payload)
+                
                 part.set_payload(payload)
 
         ############################################################################################

--- a/shared-data/default-theme/html/jsapi/message/html-sandbox.js
+++ b/shared-data/default-theme/html/jsapi/message/html-sandbox.js
@@ -196,8 +196,7 @@ Mailpile.Message.SetHTMLPolicy = function(mid, old_policy, new_policy) {
 };
 
 
-Mailpile.Message.SandboxHTML = function(part_id, $part, html_data, policy, allow_images) {
-
+Mailpile.Message.SandboxHTML = function(part_id, $part, html_data, policy, allow_images) {  
   var $iframe_html = (
     '<iframe id="message-iframe-' + part_id + '" seamless');
 {% if config.prefs.html5_sandbox %}
@@ -286,12 +285,13 @@ Mailpile.Message.SandboxHTML = function(part_id, $part, html_data, policy, allow
     ));
     $msg_details.find('.display-now').click(function() {
       $wrapper.remove();
-      Mailpile.Message.SandboxHTML(part_id, $part, html_data, 'images');
+      $msg_details.find('.html-image-question').remove();
+      Mailpile.Message.SandboxHTML(part_id, $part, html_data, 'images', true);
     });
     $msg_details.find('.display-always').click(function() {
       $wrapper.remove();
       $msg_details.find('.html-image-question').remove();
-      Mailpile.Message.SandboxHTML(part_id, $part, html_data, 'images');
+      Mailpile.Message.SandboxHTML(part_id, $part, html_data, 'images', true);
       Mailpile.Message.SetHTMLPolicy($part.closest('.has-mid').data('mid'),
                                      policy, 'images');
     });
@@ -315,7 +315,7 @@ Mailpile.Message.SandboxHTML = function(part_id, $part, html_data, policy, allow
 };
 
 
-Mailpile.Message.ShowHTML = function(mid, policy, allow_images) {
+Mailpile.Message.ShowHTML = function(mid, policy, allow_images) {  
   // HTML Parts Exist
   var $msg = $('#message-' + mid);
   var html_data = $msg.data('html');


### PR DESCRIPTION
Hello everyone!

This patch fixes issue #1476 . 

The problem: inline images are not shown in Mailpile when they refer to an attachment ContentID rather than a web address. The "src" attribute of these images point to the attachment, but the browser cannot find this address. 

The solution: replace the "cid" in the "src" attribute by the base64 image source, contained in the same message downloaded from email server, but in a separated payload. This fixes the issue. 

The patch has been tested against emails containing inline attached images coming from gmail and outlook senders.