### PR TITLE
A list or collection length can not be less than zero it can be great…

### DIFF
--- a/mailpile/plugins/crypto_gnupg.py
+++ b/mailpile/plugins/crypto_gnupg.py
@@ -346,7 +346,10 @@ class GPGKeyImportFromMail(Search):
             attid = self.data.get("att", 'application/pgp-keys')
         args.extend(["=%s" % x for x in self.data.get("mid", [])])
         eids = self._choose_messages(args)
-        if len(eids) < 0:
+        # OpenRefactory Warning: Collection length comparison should be meaningful.
+        # The length of a collection is always greater than or equal to zero.
+        # So testing that a length is less than zero is always false.
+        if len(eids) < 1:
             return self._error("No messages selected", None)
         elif len(eids) > 1:
             return self._error("One message at a time, please", None)

--- a/mailpile/workers.py
+++ b/mailpile/workers.py
@@ -275,7 +275,10 @@ class Worker(threading.Thread):
 
             with self.LOCK:
                 session, name, task = self.JOBS.pop(0)
-                if len(self.JOBS) < 0:
+                # OpenRefactory Warning: Collection length comparison should be meaningful.
+                # The length of a collection is always greater than or equal to zero.
+                # So testing that a length is less than zero is always false.
+                if len(self.JOBS) < 1:
                     now = time.time()
                     self.JOBS.extend(snt for ts, snt
                                      in self.JOBS_LATER if ts <= now)


### PR DESCRIPTION
This issue was detected in branch `master` of `Mailpile` project on the version with commit hash `0989ac`. This is an instance of an inappropriate logic.

**Fixes for inappropriate logic:**
In file: `crypto_gnupg.py` and `workers.py` the comparison of Collection length creates a logical short circuit. **iCR** suggested that the Collection length comparison should be done without creating a logical short circuit.

This issue was detected by **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. More info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)