### PR TITLE
fix(sec): upgrade cryptography to 3.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs
 setuptools>=11.3
-cryptography>=1.3.4
+cryptography>=3.3.2
 lxml>=2.3.2
 imgsize
 Jinja2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in cryptography 1.3.4
- [CVE-2020-25659](https://www.oscs1024.com/hd/CVE-2020-25659)


### What did I do？
Upgrade cryptography from 1.3.4 to 3.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS