### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/mailpile/plugins/crypto_gnupg.py
+++ b/mailpile/plugins/crypto_gnupg.py
@@ -346,7 +346,7 @@ class GPGKeyImportFromMail(Search):
             attid = self.data.get("att", 'application/pgp-keys')
         args.extend(["=%s" % x for x in self.data.get("mid", [])])
         eids = self._choose_messages(args)
-        if len(eids) < 0:
+        if not eids:
             return self._error("No messages selected", None)
         elif len(eids) > 1:
             return self._error("One message at a time, please", None)


### PR DESCRIPTION
In file: crypto_gnupg.py, the comparison of Collection length creates a logical short circuit. It will always evaluate to false since the size of the list can never be less than zero. 

I suggested that the Collection length comparison should be done without creating a logical short circuit. I suggested that the check is for emptiness of the list.

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.