### PR TITLE
Fixed inappropriate logical expression

### DIFF
--- a/mailpile/workers.py
+++ b/mailpile/workers.py
@@ -275,7 +275,7 @@ class Worker(threading.Thread):
 
             with self.LOCK:
                 session, name, task = self.JOBS.pop(0)
-                if len(self.JOBS) < 0:
+                if not self.JOBS:
                     now = time.time()
                     self.JOBS.extend(snt for ts, snt
                                      in self.JOBS_LATER if ts <= now)


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [workers.py](https://github.com/mailpile/Mailpile/tree/master/mailpile/workers.py#L281), the comparison of Collection length creates a logical short circuit. iCR suggested that the Collection length comparison should be done without creating a logical short circuit.


## Changes
- Replaced the logical expression with an estimated guess


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
